### PR TITLE
feat: 新規受講生登録機能を実装しました

### DIFF
--- a/src/main/java/portfolio/StudentManagement/controller/StudentController.java
+++ b/src/main/java/portfolio/StudentManagement/controller/StudentController.java
@@ -53,8 +53,6 @@ public class StudentController {
     if (result.hasErrors()) {
       return "registerStudent";
     }
-    // 新規受講生情報を登録する処理を実装する。
-    // コース情報も一緒に登録できるように実装する。コースは単体で良い。
     service.registerStudent(studentDetail);
     return "redirect:/studentList";
   }

--- a/src/main/java/portfolio/StudentManagement/controller/StudentController.java
+++ b/src/main/java/portfolio/StudentManagement/controller/StudentController.java
@@ -4,10 +4,14 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
 import portfolio.StudentManagement.controller.converter.StudentConverter;
 import portfolio.StudentManagement.data.Student;
 import portfolio.StudentManagement.data.StudentCourse;
+import portfolio.StudentManagement.domain.StudentDetail;
 import portfolio.StudentManagement.service.StudentService;
 
 @Controller
@@ -36,6 +40,23 @@ public class StudentController {
   public String getStudentCourseList(Model model) {
     model.addAttribute("allStudentCourseList", service.searchForAllStudentCourseList());
     return "studentCourseList";
+  }
+
+  @GetMapping("/newStudent")
+  public String newStudent(Model model) {
+    model.addAttribute("studentDetail", new StudentDetail());
+    return "registerStudent";
+  }
+
+  @PostMapping("/registerStudent")
+  public String registerStudent(@ModelAttribute StudentDetail studentDetail, BindingResult result) {
+    if (result.hasErrors()) {
+      return "registerStudent";
+    }
+    // 新規受講生情報を登録する処理を実装する。
+    service.registerStudent(studentDetail);
+    // コース情報も一緒に登録できるように実装する。コースは単体で良い。
+    return "redirect:/studentList";
   }
 
 }

--- a/src/main/java/portfolio/StudentManagement/controller/StudentController.java
+++ b/src/main/java/portfolio/StudentManagement/controller/StudentController.java
@@ -54,8 +54,8 @@ public class StudentController {
       return "registerStudent";
     }
     // 新規受講生情報を登録する処理を実装する。
-    service.registerStudent(studentDetail);
     // コース情報も一緒に登録できるように実装する。コースは単体で良い。
+    service.registerStudent(studentDetail);
     return "redirect:/studentList";
   }
 

--- a/src/main/java/portfolio/StudentManagement/repository/StudentCourseRepository.java
+++ b/src/main/java/portfolio/StudentManagement/repository/StudentCourseRepository.java
@@ -1,21 +1,28 @@
 package portfolio.StudentManagement.repository;
 
 import java.util.List;
+import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 import org.apache.ibatis.annotations.Select;
+import portfolio.StudentManagement.data.Student;
 import portfolio.StudentManagement.data.StudentCourse;
 
 /**
- * 受講生コース情報を扱うリポジトリ
- * 全件検索や単一条件での検索が行えるクラスです
+ * 受講生コース情報を扱うリポジトリ 全件検索や単一条件での検索が行えるクラスです
  */
 @Mapper
 public interface StudentCourseRepository {
 
   /**
    * 全件検索します
+   *
    * @return 全件検索した受講生コースの一覧
    */
   @Select("SELECT * FROM students_courses")
   List<StudentCourse> selectAllStudentCourseList();
+
+  @Insert("INSERT INTO students_courses (id, student_id, course_name, start_date, end_date) VALUES(#{studentCourse.id}, #{student.id}, #{studentCourse.courseName}, CURRENT_TIMESTAMP, DATE_ADD(CURRENT_TIMESTAMP, INTERVAL 1 YEAR))")
+  void createStudentCourse(@Param("student") Student student,
+      @Param("studentCourse") StudentCourse studentCourse);
 }

--- a/src/main/java/portfolio/StudentManagement/repository/StudentCourseRepository.java
+++ b/src/main/java/portfolio/StudentManagement/repository/StudentCourseRepository.java
@@ -3,6 +3,7 @@ package portfolio.StudentManagement.repository;
 import java.util.List;
 import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Options;
 import org.apache.ibatis.annotations.Param;
 import org.apache.ibatis.annotations.Select;
 import portfolio.StudentManagement.data.Student;
@@ -22,7 +23,8 @@ public interface StudentCourseRepository {
   @Select("SELECT * FROM students_courses")
   List<StudentCourse> selectAllStudentCourseList();
 
-  @Insert("INSERT INTO students_courses (id, student_id, course_name, start_date, end_date) VALUES(#{studentCourse.id}, #{student.id}, #{studentCourse.courseName}, CURRENT_TIMESTAMP, DATE_ADD(CURRENT_TIMESTAMP, INTERVAL 1 YEAR))")
+  @Insert("INSERT INTO students_courses (student_id, course_name, start_date, end_date) VALUES((SELECT id FROM students WHERE email = #{student.email}), #{studentCourse.courseName}, CURRENT_TIMESTAMP, DATE_ADD(CURRENT_TIMESTAMP, INTERVAL 1 YEAR))")
+  @Options(useGeneratedKeys = true, keyProperty = "studentCourse.id")
   void createStudentCourse(@Param("student") Student student,
       @Param("studentCourse") StudentCourse studentCourse);
 }

--- a/src/main/java/portfolio/StudentManagement/repository/StudentRepository.java
+++ b/src/main/java/portfolio/StudentManagement/repository/StudentRepository.java
@@ -1,20 +1,27 @@
 package portfolio.StudentManagement.repository;
 
 import java.util.List;
+import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 import org.apache.ibatis.annotations.Select;
 import portfolio.StudentManagement.data.Student;
 
 /**
- * 受講生情報を扱うリポジトリ
- * 全件検索や単一条件での検索が行えるクラスです
+ * 受講生情報を扱うリポジトリ 全件検索や単一条件での検索が行えるクラスです
  */
 @Mapper
 public interface StudentRepository {
+
   /**
    * 全件検索します
+   *
    * @return 全件検索した受講生情報の一覧
    */
   @Select("SELECT * FROM students")
   List<Student> selectAllStudentList();
+
+
+  @Insert("INSERT INTO students (id, full_name, kana, nick_name, email, city, age, gender) VALUES(#{student.id},#{student.fullName},#{student.kana},#{student.nickName},#{student.email},#{student.city},#{student.age},#{student.gender})")
+  void createStudent(@Param("student") Student student);
 }

--- a/src/main/java/portfolio/StudentManagement/repository/StudentRepository.java
+++ b/src/main/java/portfolio/StudentManagement/repository/StudentRepository.java
@@ -3,6 +3,7 @@ package portfolio.StudentManagement.repository;
 import java.util.List;
 import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Options;
 import org.apache.ibatis.annotations.Param;
 import org.apache.ibatis.annotations.Select;
 import portfolio.StudentManagement.data.Student;
@@ -22,6 +23,7 @@ public interface StudentRepository {
   List<Student> selectAllStudentList();
 
 
-  @Insert("INSERT INTO students (id, full_name, kana, nick_name, email, city, age, gender) VALUES(#{student.id},#{student.fullName},#{student.kana},#{student.nickName},#{student.email},#{student.city},#{student.age},#{student.gender})")
+  @Insert("INSERT INTO students (full_name, kana, nick_name, email, city, age, gender) VALUES(#{student.fullName},#{student.kana},#{student.nickName},#{student.email},#{student.city},#{student.age},#{student.gender})")
+  @Options(useGeneratedKeys = true, keyProperty = "student.id")
   void createStudent(@Param("student") Student student);
 }

--- a/src/main/java/portfolio/StudentManagement/service/StudentService.java
+++ b/src/main/java/portfolio/StudentManagement/service/StudentService.java
@@ -5,11 +5,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import portfolio.StudentManagement.data.Student;
 import portfolio.StudentManagement.data.StudentCourse;
+import portfolio.StudentManagement.domain.StudentDetail;
 import portfolio.StudentManagement.repository.StudentCourseRepository;
 import portfolio.StudentManagement.repository.StudentRepository;
 
 @Service
 public class StudentService {
+
   private StudentRepository studentRepository;
   private StudentCourseRepository studentCourseRepository;
 
@@ -26,5 +28,10 @@ public class StudentService {
 
   public List<StudentCourse> searchForAllStudentCourseList() {
     return studentCourseRepository.selectAllStudentCourseList();
+  }
+
+  public void registerStudent(StudentDetail studentDetail) {
+    Student newStudent = studentDetail.getStudent();
+    studentRepository.createStudent(newStudent);
   }
 }

--- a/src/main/java/portfolio/StudentManagement/service/StudentService.java
+++ b/src/main/java/portfolio/StudentManagement/service/StudentService.java
@@ -3,6 +3,7 @@ package portfolio.StudentManagement.service;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import portfolio.StudentManagement.data.Student;
 import portfolio.StudentManagement.data.StudentCourse;
 import portfolio.StudentManagement.domain.StudentDetail;
@@ -30,8 +31,11 @@ public class StudentService {
     return studentCourseRepository.selectAllStudentCourseList();
   }
 
+  @Transactional
   public void registerStudent(StudentDetail studentDetail) {
     Student newStudent = studentDetail.getStudent();
+    StudentCourse newStudentCourse = studentDetail.getStudentCourseList().getFirst();
     studentRepository.createStudent(newStudent);
+    studentCourseRepository.createStudentCourse(newStudent, newStudentCourse);
   }
 }

--- a/src/main/resources/templates/registerStudent.html
+++ b/src/main/resources/templates/registerStudent.html
@@ -52,6 +52,19 @@
   </div>
 
   <div>
+    <label for="courseId">コースID</label>
+    <input type="number" th:field="*{studentCourseList[0].id}" id="courseId" required>
+  </div>
+  <div>
+    <label for="courseName">性別</label>
+    <select th:field="*{studentCourseList[0].courseName}" id="courseName">
+      <option value="Javaフルコース">Javaフルコース</option>
+      <option value="AWSフルコース">AWSフルコース</option>
+      <option value="デザインコース">デザインコース</option>
+    </select>
+  </div>
+
+  <div>
     <button type="submit">登録</button>
   </div>
 

--- a/src/main/resources/templates/registerStudent.html
+++ b/src/main/resources/templates/registerStudent.html
@@ -8,11 +8,6 @@
 
 <form th:action="@{/registerStudent}" th:object="${studentDetail}" method="post">
   <div>
-    <label for="id">ID</label>
-    <input type="number" th:field="*{student.id}" id="id" required>
-  </div>
-
-  <div>
     <label for="fullName">名前</label>
     <input type="text" th:field="*{student.fullName}" id="fullName" required>
   </div>
@@ -34,7 +29,7 @@
 
   <div>
     <label for="city">住所</label>
-    <input type="text" th:field="*{student.city}" id="city">
+    <input type="text" th:field="*{student.city}" id="city" required>
   </div>
 
   <div>
@@ -52,11 +47,7 @@
   </div>
 
   <div>
-    <label for="courseId">コースID</label>
-    <input type="number" th:field="*{studentCourseList[0].id}" id="courseId" required>
-  </div>
-  <div>
-    <label for="courseName">性別</label>
+    <label for="courseName">受講コース</label>
     <select th:field="*{studentCourseList[0].courseName}" id="courseName">
       <option value="Javaフルコース">Javaフルコース</option>
       <option value="AWSフルコース">AWSフルコース</option>

--- a/src/main/resources/templates/registerStudent.html
+++ b/src/main/resources/templates/registerStudent.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="ja" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <title>受講生登録</title>
+</head>
+<body>
+<h1>受講生登録</h1>
+
+<form th:action="@{/registerStudent}" th:object="${studentDetail}" method="post">
+  <div>
+    <label for="id">ID</label>
+    <input type="number" th:field="*{student.id}" id="id" required>
+  </div>
+
+  <div>
+    <label for="fullName">名前</label>
+    <input type="text" th:field="*{student.fullName}" id="fullName" required>
+  </div>
+
+  <div>
+    <label for="kana">フリガナ</label>
+    <input type="text" th:field="*{student.kana}" id="kana">
+  </div>
+
+  <div>
+    <label for="nickName">ニックネーム</label>
+    <input type="text" th:field="*{student.nickName}" id="nickName">
+  </div>
+
+  <div>
+    <label for="email">メールアドレス</label>
+    <input type="email" th:field="*{student.email}" id="email" required>
+  </div>
+
+  <div>
+    <label for="city">住所</label>
+    <input type="text" th:field="*{student.city}" id="city">
+  </div>
+
+  <div>
+    <label for="age">年齢</label>
+    <input type="number" th:field="*{student.age}" id="age" required>
+  </div>
+
+  <div>
+    <label for="gender">性別</label>
+    <select th:field="*{student.gender}" id="gender">
+      <option value="Male">男性</option>
+      <option value="Female">女性</option>
+      <option value="Non-binary">ノンバイナリー</option>
+    </select>
+  </div>
+
+  <div>
+    <button type="submit">登録</button>
+  </div>
+
+</form>
+</body>
+</html>


### PR DESCRIPTION
## 変更の概要
- 新規受講生情報と受講コース情報をセットで登録する機能を実装しました
- Thymeleafで作成した画面から、StudentDetailを受け取り、Service層でStudentRepository,StudentCourseRepositoryそれぞれに登録するような処理を実装しています

close #17 

## なぜこの変更をするのか
- 画面からのPOST処理の練習のため
- 新規受講生情報を手軽に登録するため

## 変更内容

https://github.com/user-attachments/assets/d6f32198-f742-4424-8cf5-d63510b382bf



## どうやるのか
- `/newStudent`へアクセス
- フォームを入力
  - emailはUnique制約があります
- 登録ボタンを押下
- 受講生情報はstudentsテーブルに、受講生コース情報はstudents_coursesテーブルに保存されます

## とくにレビューしてほしいところ
以下の講義動画との差分について実装内容に違和感がないかご確認いただけますと嬉しいです
### HTML側との連携内容
- 該当ファイル: registerStudent.html
  - studentDetailがもともと持っているstudentCourseの0番目を指定して、フォームで入力されたコース名を入れられるようにしている
- 講義動画では以下のように実装されていました
  - studentDetailに空のリストstudentCoursesをセットし、それをHTML側に渡す
  - そのstudentCoursesをth:eachを使って展開し、フォームで入力されたコース名を入れられるようにしている
    
### Repositoryとの連携内容
- 該当ファイル: StudentService.java, StudentCourseRepository.java
  - Service層
    - studentCourseが一つしかないことを前提に最初の要素ををgetFirstで取得している
  - DB層 
    - studentDetailのstudentオブジェクトを受け取れるようにしている
    - ユニーク制約がかかっているemailを使ってstudentsテーブルから該当のidを取得して設定するようにSQL文を記述
    - 受講開始日などはMySQL側で設定するようにSQL文を記述している
- 講義動画では以下のように実装されていますた
  - Service層：StudentCourses(List)をループで回して、リストの中身を扱っている
  - studentCourseに手動でstudentIdや受講開始日、受講修了予定日をセットしている
    
## 備考
- studentRepositoryとstudentCourseRepositoryに分けてRepositoryを作成している点については以前ご確認いただいています