### PR TITLE
feat: 受講生の論理削除機能を実装しました

### DIFF
--- a/src/main/java/portfolio/StudentManagement/repository/StudentCourseRepository.java
+++ b/src/main/java/portfolio/StudentManagement/repository/StudentCourseRepository.java
@@ -25,7 +25,7 @@ public interface StudentCourseRepository {
   List<StudentCourse> selectAllCourseList();
 
   @Select("SELECT * FROM students_courses WHERE student_id = #{studentId}")
-  List<StudentCourse> selectCourseListByStudentId(@Param("studentId") String studentId);
+  List<StudentCourse> selectCourseListByStudentId(String studentId);
 
   @Insert("INSERT INTO students_courses (student_id, course_name, start_date, end_date) VALUES((SELECT id FROM students WHERE email = #{student.email}), #{studentCourse.courseName}, CURRENT_TIMESTAMP, DATE_ADD(CURRENT_TIMESTAMP, INTERVAL 1 YEAR))")
   @Options(useGeneratedKeys = true, keyProperty = "studentCourse.id")
@@ -33,8 +33,8 @@ public interface StudentCourseRepository {
       @Param("studentCourse") StudentCourse studentCourse);
 
   @Update(
-      "UPDATE students_courses SET course_name = #{studentCourse.courseName} "
-          + "WHERE id = #{studentCourse.id}"
+      "UPDATE students_courses SET course_name = #{courseName} "
+          + "WHERE id = #{id}"
   )
-  void updateStudentCourse(@Param("studentCourse") StudentCourse studentCourse);
+  void updateStudentCourse(StudentCourse studentCourse);
 }

--- a/src/main/java/portfolio/StudentManagement/repository/StudentRepository.java
+++ b/src/main/java/portfolio/StudentManagement/repository/StudentRepository.java
@@ -4,7 +4,6 @@ import java.util.List;
 import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Options;
-import org.apache.ibatis.annotations.Param;
 import org.apache.ibatis.annotations.Select;
 import org.apache.ibatis.annotations.Update;
 import portfolio.StudentManagement.data.Student;
@@ -24,17 +23,17 @@ public interface StudentRepository {
   List<Student> selectAllStudentList();
 
   @Select("SELECT * FROM students WHERE id = #{id}")
-  Student selectStudentById(@Param("id") String id);
+  Student selectStudentById(String id);
 
-  @Insert("INSERT INTO students (full_name, kana, nick_name, email, city, age, gender) VALUES(#{student.fullName},#{student.kana},#{student.nickName},#{student.email},#{student.city},#{student.age},#{student.gender})")
-  @Options(useGeneratedKeys = true, keyProperty = "student.id")
-  void createStudent(@Param("student") Student student);
+  @Insert("INSERT INTO students (full_name, kana, nick_name, email, city, age, gender) VALUES(#{fullName},#{kana},#{nickName},#{email},#{city},#{age},#{gender})")
+  @Options(useGeneratedKeys = true, keyProperty = "id")
+  void createStudent(Student student);
 
   @Update(
-      "UPDATE students SET full_name = #{student.fullName}, kana = #{student.kana}, nick_name = #{student.nickName}, email = #{student.email}, city = #{student.city}, age = #{student.age}, gender = #{student.gender}, remark = #{student.remark} "
-          + "WHERE id = #{student.id}"
+      "UPDATE students SET full_name = #{fullName}, kana = #{kana}, nick_name = #{nickName}, email = #{email}, city = #{city}, age = #{age}, gender = #{gender}, remark = #{remark} "
+          + "WHERE id = #{id}"
   )
-  void updateStudent(@Param("student") Student student);
+  void updateStudent(Student student);
 }
 
 

--- a/src/main/java/portfolio/StudentManagement/repository/StudentRepository.java
+++ b/src/main/java/portfolio/StudentManagement/repository/StudentRepository.java
@@ -19,7 +19,7 @@ public interface StudentRepository {
    *
    * @return 全件検索した受講生情報の一覧
    */
-  @Select("SELECT * FROM students")
+  @Select("SELECT * FROM students WHERE is_deleted = false")
   List<Student> selectAllStudentList();
 
   @Select("SELECT * FROM students WHERE id = #{id}")
@@ -30,7 +30,7 @@ public interface StudentRepository {
   void createStudent(Student student);
 
   @Update(
-      "UPDATE students SET full_name = #{fullName}, kana = #{kana}, nick_name = #{nickName}, email = #{email}, city = #{city}, age = #{age}, gender = #{gender}, remark = #{remark}, isDeleted = #{isDeleted} "
+      "UPDATE students SET full_name = #{fullName}, kana = #{kana}, nick_name = #{nickName}, email = #{email}, city = #{city}, age = #{age}, gender = #{gender}, remark = #{remark}, is_deleted = #{isDeleted} "
           + "WHERE id = #{id}"
   )
   void updateStudent(Student student);

--- a/src/main/java/portfolio/StudentManagement/repository/StudentRepository.java
+++ b/src/main/java/portfolio/StudentManagement/repository/StudentRepository.java
@@ -25,12 +25,12 @@ public interface StudentRepository {
   @Select("SELECT * FROM students WHERE id = #{id}")
   Student selectStudentById(String id);
 
-  @Insert("INSERT INTO students (full_name, kana, nick_name, email, city, age, gender) VALUES(#{fullName},#{kana},#{nickName},#{email},#{city},#{age},#{gender})")
+  @Insert("INSERT INTO students (full_name, kana, nick_name, email, city, age, gender) VALUES(#{fullName}, #{kana}, #{nickName}, #{email}, #{city}, #{age}, #{gender})")
   @Options(useGeneratedKeys = true, keyProperty = "id")
   void createStudent(Student student);
 
   @Update(
-      "UPDATE students SET full_name = #{fullName}, kana = #{kana}, nick_name = #{nickName}, email = #{email}, city = #{city}, age = #{age}, gender = #{gender}, remark = #{remark} "
+      "UPDATE students SET full_name = #{fullName}, kana = #{kana}, nick_name = #{nickName}, email = #{email}, city = #{city}, age = #{age}, gender = #{gender}, remark = #{remark}, isDeleted = #{isDeleted} "
           + "WHERE id = #{id}"
   )
   void updateStudent(Student student);

--- a/src/main/resources/templates/updateStudent.html
+++ b/src/main/resources/templates/updateStudent.html
@@ -8,7 +8,6 @@
 
 <form th:action="@{/updateStudent}" th:object="${studentDetail}" th:method="patch">
   <input type="hidden" th:field="*{student.id}">
-  <input type="hidden" th:field="*{student.isDeleted}">
 
   <div>
     <label for="fullName">名前</label>
@@ -59,6 +58,11 @@
   <div>
     <label for="remark">備考</label>
     <input type="text" th:field="*{student.remark}" id="remark">
+  </div>
+
+  <div>
+    <input type="checkbox" th:field="*{student.isDeleted}" id="isDeleted">
+    <label for="isDeleted">キャンセル</label>
   </div>
 
   <div th:each="studentCourse, stat : ${studentDetail.studentCourseList}">


### PR DESCRIPTION
## 変更の概要
受講生の論理削除機能を実装しました。
具体的には、isDeletedがtrueになった場合、全件検索の対象から外れ、全受講生リストに記載されなくなります、
close #20 

## なぜこの変更をするのか
- キャンセルがあった受講生を一覧画面から削除するため
- 後々キャンセルフラグの再変更をする場面も想定し、論理削除に留め、idを使った単一検索には引っかかるように実装
- データ分析等の用途のため、DBからレコード自体は削除しない

## 変更内容
https://github.com/user-attachments/assets/4648932c-beac-4458-b088-5ece9600cce4

## どうやるのか
- 受講生更新画面でキャンセルにチェックをいれ、更新ボタンを押下
- 受講生一覧画面から情報が消える
- キャンセルのチェックを外したい場合は、別途DBからIDを調べ、直接`student/id`に遷移

## 備考
本PRはレビュー不要です