### PR TITLE
fix: job間でファイルの共有ができるようにCI/CD設定ファイルを修正しました

### DIFF
--- a/.github/workflows/JavaTest.yml
+++ b/.github/workflows/JavaTest.yml
@@ -39,11 +39,22 @@ jobs:
       - name: Build with Gradle Wrapper
         run: ./gradlew bootJar
 
+      - name: Upload Build Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: built-jar
+          path: build/libs/*.jar
+
   deploy:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     needs: build-and-test
     steps:
+      - name: Download Build Artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: built-jar
+          
       - name: SCP Copy Application to EC2
         env:
           PRIVATE_KEY: ${{ secrets.AWS_EC2_PRIVATE_KEY }}


### PR DESCRIPTION
## 変更の概要
- エラーが発生していたCDの設定を修正しました

### 関連プルリクエスト
#46 

## なぜこの変更をするのか
- デバッグのため

## エラー原因と変更内容
- エラー原因
  - GitHub Actionsの仕様上、job毎に仮想環境が作られる
  - ビルドとテスト用のjobで作成したファイルをデプロイ用のjobで送信しようとしたところ、ファイルがないため送信時にエラーが発生する
- 変更内容
  - ファイル共有を行う設定を追加しました
