### PR TITLE
fix: job間でファイルの共有ができるようにCI/CD設定ファイルを修正しました

### DIFF
--- a/.github/workflows/JavaTest.yml
+++ b/.github/workflows/JavaTest.yml
@@ -12,7 +12,6 @@ env:
   SRC_PATH: 'build/libs/*.jar'
   DEST_PATH: '/home/ec2-user/portfolio-student-management.jar'
 
-
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
@@ -54,7 +53,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: built-jar
-          
+
       - name: SCP Copy Application to EC2
         env:
           PRIVATE_KEY: ${{ secrets.AWS_EC2_PRIVATE_KEY }}


### PR DESCRIPTION
## 変更の概要
- エラーが発生していたCDの設定を修正しました

### 関連プルリクエスト
#46 

## なぜこの変更をするのか
- デバッグのため

## エラー原因と変更内容
- エラー原因
  - GitHub Actionsの仕様上、job毎に仮想環境が作られる
  - ビルドとテスト用のjobで作成したファイルをデプロイ用のjobで送信しようとしたところ、ファイルがないため送信時にエラーが発生する
- 変更内容
  - ファイル共有を行う設定を追加しました
