### PR TITLE
feat: 受講生一覧画面を作成しました

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -18,7 +18,7 @@
       "error",
       {
         "trailingComma": "all",
-        "endOfLine": "lf",
+        "endOfLine": "crlf",
         "semi": false,
         "singleQuote": true,
         "printWidth": 80,

--- a/frontend/src/components/FilterInputs.tsx
+++ b/frontend/src/components/FilterInputs.tsx
@@ -1,0 +1,150 @@
+import {
+  Button,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  SelectChangeEvent,
+  Stack,
+  TextField,
+} from '@mui/material'
+import React from 'react'
+
+type FilterInputsProps = {
+  fullName: string
+  setFullName: React.Dispatch<React.SetStateAction<string>>
+  kana: string
+  setKana: React.Dispatch<React.SetStateAction<string>>
+  nickName: string
+  setNickName: React.Dispatch<React.SetStateAction<string>>
+  email: string
+  setEmail: React.Dispatch<React.SetStateAction<string>>
+  city: string
+  setCity: React.Dispatch<React.SetStateAction<string>>
+  maxAge: string
+  setMaxAge: React.Dispatch<React.SetStateAction<string>>
+  minAge: string
+  setMinAge: React.Dispatch<React.SetStateAction<string>>
+  gender: string
+  setGender: React.Dispatch<React.SetStateAction<string>>
+  remark: string
+  setRemark: React.Dispatch<React.SetStateAction<string>>
+}
+
+const FilterInputs: React.FC<FilterInputsProps> = ({
+  fullName,
+  setFullName,
+  kana,
+  setKana,
+  nickName,
+  setNickName,
+  email,
+  setEmail,
+  city,
+  setCity,
+  maxAge,
+  setMaxAge,
+  minAge,
+  setMinAge,
+  gender,
+  setGender,
+  remark,
+  setRemark,
+}) => {
+  const handleTextInputChange =
+    (setter: React.Dispatch<React.SetStateAction<string>>) =>
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      setter(event.target.value)
+    }
+  const handleSelectChange =
+    (setter: React.Dispatch<React.SetStateAction<string>>) =>
+    (event: SelectChangeEvent<string>) => {
+      setter(event.target.value as string)
+    }
+  const handleReset = () => {
+    setFullName('')
+    setKana('')
+    setNickName('')
+    setEmail('')
+    setCity('')
+    setMaxAge('')
+    setMinAge('')
+    setGender('')
+    setRemark('')
+  }
+
+  return (
+    <div>
+      <Stack direction="row" spacing={2}>
+        <TextField
+          label="氏名"
+          variant="outlined"
+          value={fullName}
+          onChange={handleTextInputChange(setFullName)}
+        />
+        <TextField
+          label="カナ名"
+          variant="outlined"
+          value={kana}
+          onChange={handleTextInputChange(setKana)}
+        />
+        <TextField
+          label="ニックネーム"
+          variant="outlined"
+          value={nickName}
+          onChange={handleTextInputChange(setNickName)}
+        />
+        <TextField
+          label="メールアドレス"
+          variant="outlined"
+          value={email}
+          onChange={handleTextInputChange(setEmail)}
+        />
+        <TextField
+          label="居住地域"
+          variant="outlined"
+          value={city}
+          onChange={handleTextInputChange(setCity)}
+        />
+      </Stack>
+      <Stack direction="row" spacing={2} sx={{ mt: 1 }}>
+        <TextField
+          label="最大年齢"
+          variant="outlined"
+          value={maxAge}
+          onChange={handleTextInputChange(setMaxAge)}
+        />
+        <TextField
+          label="最小年齢"
+          variant="outlined"
+          value={minAge}
+          onChange={handleTextInputChange(setMinAge)}
+        />
+        <FormControl sx={{ minWidth: 120 }}>
+          <InputLabel id="gender">性別</InputLabel>
+          <Select
+            labelId="gender"
+            value={gender}
+            label="gender"
+            onChange={handleSelectChange(setGender)}
+          >
+            <MenuItem value={'Male'}>Male</MenuItem>
+            <MenuItem value={'Female'}>Female</MenuItem>
+            <MenuItem value={'NON_BINARY'}>NON_BINARY</MenuItem>
+          </Select>
+        </FormControl>
+        <TextField
+          label="備考"
+          variant="outlined"
+          value={remark}
+          onChange={handleTextInputChange(setRemark)}
+        />
+        <Button variant="contained" onClick={handleReset}>
+          リセット
+        </Button>
+      </Stack>
+    </div>
+  )
+}
+
+export default FilterInputs

--- a/frontend/src/components/StudentTable.tsx
+++ b/frontend/src/components/StudentTable.tsx
@@ -1,0 +1,63 @@
+import {
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+} from '@mui/material'
+import React from 'react'
+
+type StudentTableProps = {
+  data: {
+    student: {
+      id: string
+      fullName: string
+      kana: string
+      nickName: string
+      email: string
+      city: string
+      age: number
+      gender: string
+      remark: string
+    }
+  }[]
+}
+
+const StudentTable: React.FC<StudentTableProps> = ({ data }) => {
+  return (
+    <TableContainer component={Paper}>
+      <Table sx={{ minWidth: 650 }} aria-label="simple table">
+        <TableHead>
+          <TableRow>
+            <TableCell>氏名</TableCell>
+            <TableCell>カナ名</TableCell>
+            <TableCell>ニックネーム</TableCell>
+            <TableCell>メールアドレス</TableCell>
+            <TableCell>居住地域</TableCell>
+            <TableCell>年齢</TableCell>
+            <TableCell>性別</TableCell>
+            <TableCell>備考</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {data.map((studentData) => (
+            <TableRow key={studentData.student.id}>
+              <TableCell>{studentData.student.fullName}</TableCell>
+              <TableCell>{studentData.student.kana}</TableCell>
+              <TableCell>{studentData.student.nickName}</TableCell>
+              <TableCell>{studentData.student.email}</TableCell>
+              <TableCell>{studentData.student.city}</TableCell>
+              <TableCell>{studentData.student.age}</TableCell>
+              <TableCell>{studentData.student.gender}</TableCell>
+              <TableCell>{studentData.student.remark}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  )
+}
+
+export default StudentTable

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -1,4 +1,15 @@
-import { Box, Container, Typography, Card, CardContent } from '@mui/material'
+import {
+  Box,
+  Container,
+  Typography,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+} from '@mui/material'
 import type { NextPage } from 'next'
 import useSWR from 'swr'
 import { fetcher } from '@/utils'
@@ -7,17 +18,24 @@ type StudentProps = {
   student: {
     id: string
     fullName: string
-    age: number
+    kana: string
+    nickName: string
     email: string
     city: string
+    age: number
     gender: string
+    remark: string
   }
   studentCourseList: {
     id: string
     courseName: string
-    status: string
     startDate: string
     endDate: string
+    enrollmentStatus: {
+      id: string
+      status: string
+      createdAt: string
+    }
   }[]
 }
 
@@ -32,25 +50,44 @@ const StudentPage: NextPage = () => {
 
   return (
     <Box sx={{ backgroundColor: '#f9f9f9', minHeight: '100vh', py: 4 }}>
-      <Container maxWidth="md">
+      <Container maxWidth="lg">
         <Typography variant="h4" gutterBottom>
-          学生情報
+          受講生一覧
         </Typography>
 
-        {/* 学生の基本情報 */}
-        {studentsData.map((studentData: StudentProps) => (
-          // eslint-disable-next-line react/jsx-key
-          <Card sx={{ mb: 4 }}>
-            <CardContent>
-              <Typography variant="h6">基本情報</Typography>
-              <Typography>名前: {studentData.student.fullName}</Typography>
-              <Typography>年齢: {studentData.student.age}</Typography>
-              <Typography>メール: {studentData.student.email}</Typography>
-              <Typography>住所: {studentData.student.city}</Typography>
-              <Typography>性別: {studentData.student.gender}</Typography>
-            </CardContent>
-          </Card>
-        ))}
+        <TableContainer component={Paper}>
+          <Table sx={{ minWidth: 650 }} aria-label="simple table">
+            <TableHead>
+              <TableRow>
+                <TableCell>氏名</TableCell>
+                <TableCell>カナ名</TableCell>
+                <TableCell>ニックネーム</TableCell>
+                <TableCell>メールアドレス</TableCell>
+                <TableCell>居住地域</TableCell>
+                <TableCell>年齢</TableCell>
+                <TableCell>性別</TableCell>
+                <TableCell>備考</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {studentsData.map((studentData: StudentProps) => (
+                <TableRow
+                  key={studentData.student.id}
+                  sx={{ '&:last-child td, &:last-child th': { border: 0 } }}
+                >
+                  <TableCell>{studentData.student.fullName}</TableCell>
+                  <TableCell>{studentData.student.kana}</TableCell>
+                  <TableCell>{studentData.student.nickName}</TableCell>
+                  <TableCell>{studentData.student.email}</TableCell>
+                  <TableCell>{studentData.student.city}</TableCell>
+                  <TableCell>{studentData.student.age}</TableCell>
+                  <TableCell>{studentData.student.gender}</TableCell>
+                  <TableCell>{studentData.student.remark}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
       </Container>
     </Box>
   )

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -1,24 +1,12 @@
-import {
-  Box,
-  Container,
-  Typography,
-  Paper,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Stack,
-  TextField,
-  Button,
-} from '@mui/material'
+import { Box, Container, Typography } from '@mui/material'
 import type { NextPage } from 'next'
 import { useEffect, useState } from 'react'
 import useSWR from 'swr'
+import FilterInputs from '@/components/FilterInputs'
+import StudentTable from '@/components/StudentTable'
 import { fetcher } from '@/utils'
 
-type StudentProps = {
+export type StudentProps = {
   student: {
     id: string
     fullName: string
@@ -55,7 +43,7 @@ const StudentPage: NextPage = () => {
   const [minAge, setMinAge] = useState('')
   const [gender, setGender] = useState('')
   const [remark, setRemark] = useState('')
-  const [fillteredData, setFilteredData] = useState<StudentProps[]>([])
+  const [filteredData, setFilteredData] = useState<StudentProps[]>([])
 
   useEffect(() => {
     if (data) {
@@ -126,24 +114,6 @@ const StudentPage: NextPage = () => {
   if (error) return <div>An error has occurred.</div>
   if (!data) return <div>Loading...</div>
 
-  const handleInputChange =
-    (setter: React.Dispatch<React.SetStateAction<string>>) =>
-    (event: React.ChangeEvent<HTMLInputElement>) => {
-      setter(event.target.value)
-    }
-
-  const handleReset = () => {
-    setFullName('')
-    setKana('')
-    setNickName('')
-    setEmail('')
-    setCity('')
-    setMaxAge('')
-    setMinAge('')
-    setGender('')
-    setRemark('')
-  }
-
   return (
     <Box sx={{ backgroundColor: '#f9f9f9', minHeight: '100vh', py: 4 }}>
       <Container maxWidth="lg">
@@ -151,102 +121,28 @@ const StudentPage: NextPage = () => {
           受講生一覧
         </Typography>
 
-        <Stack direction="row" spacing={2}>
-          <TextField
-            label="氏名"
-            value={fullName}
-            variant="outlined"
-            onChange={handleInputChange(setFullName)}
-          />
-          <TextField
-            label="カナ名"
-            value={kana}
-            variant="outlined"
-            onChange={handleInputChange(setKana)}
-          />
-          <TextField
-            label="ニックネーム"
-            value={nickName}
-            variant="outlined"
-            onChange={handleInputChange(setNickName)}
-          />
-          <TextField
-            label="メールアドレス"
-            value={email}
-            variant="outlined"
-            onChange={handleInputChange(setEmail)}
-          />
-          <TextField
-            label="居住地域"
-            value={city}
-            variant="outlined"
-            onChange={handleInputChange(setCity)}
-          />
-        </Stack>
+        <FilterInputs
+          fullName={fullName}
+          setFullName={setFullName}
+          kana={kana}
+          setKana={setKana}
+          nickName={nickName}
+          setNickName={setNickName}
+          email={email}
+          setEmail={setEmail}
+          city={city}
+          setCity={setCity}
+          maxAge={maxAge}
+          setMaxAge={setMaxAge}
+          minAge={minAge}
+          setMinAge={setMinAge}
+          gender={gender}
+          setGender={setGender}
+          remark={remark}
+          setRemark={setRemark}
+        />
 
-        <Stack direction="row" spacing={2} sx={{ mt: 1, mb: 1 }}>
-          <TextField
-            label="最大年齢"
-            value={maxAge}
-            variant="outlined"
-            onChange={handleInputChange(setMaxAge)}
-          />
-          <TextField
-            label="最小年齢"
-            value={minAge}
-            variant="outlined"
-            onChange={handleInputChange(setMinAge)}
-          />
-          <TextField
-            label="性別"
-            value={gender}
-            variant="outlined"
-            onChange={handleInputChange(setGender)}
-          />
-          <TextField
-            label="備考"
-            value={remark}
-            variant="outlined"
-            onChange={handleInputChange(setRemark)}
-          />
-          <Button variant="contained" onClick={handleReset}>
-            リセット
-          </Button>
-        </Stack>
-
-        <TableContainer component={Paper}>
-          <Table sx={{ minWidth: 650 }} aria-label="simple table">
-            <TableHead>
-              <TableRow>
-                <TableCell>氏名</TableCell>
-                <TableCell>カナ名</TableCell>
-                <TableCell>ニックネーム</TableCell>
-                <TableCell>メールアドレス</TableCell>
-                <TableCell>居住地域</TableCell>
-                <TableCell>年齢</TableCell>
-                <TableCell>性別</TableCell>
-                <TableCell>備考</TableCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {fillteredData.map((studentData: StudentProps) => (
-                <TableRow
-                  key={studentData.student.id}
-                  sx={{ '&:last-child td, &:last-child th': { border: 0 } }}
-                >
-                  <TableCell>{studentData.student.fullName}</TableCell>
-                  <TableCell>{studentData.student.kana}</TableCell>
-                  <TableCell>{studentData.student.nickName}</TableCell>
-                  <TableCell>{studentData.student.email}</TableCell>
-                  <TableCell>{studentData.student.city}</TableCell>
-                  <TableCell>{studentData.student.age}</TableCell>
-                  <TableCell>{studentData.student.gender}</TableCell>
-                  <TableCell>{studentData.student.remark}</TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        </TableContainer>
+        <StudentTable data={filteredData} />
       </Container>
     </Box>
   )

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -9,8 +9,12 @@ import {
   TableContainer,
   TableHead,
   TableRow,
+  Stack,
+  TextField,
+  Button,
 } from '@mui/material'
 import type { NextPage } from 'next'
+import { useEffect, useState } from 'react'
 import useSWR from 'swr'
 import { fetcher } from '@/utils'
 
@@ -42,11 +46,103 @@ type StudentProps = {
 const StudentPage: NextPage = () => {
   const url = 'http://localhost:8080/students'
   const { data, error } = useSWR(url, fetcher)
+  const [fullName, setFullName] = useState('')
+  const [kana, setKana] = useState('')
+  const [nickName, setNickName] = useState('')
+  const [email, setEmail] = useState('')
+  const [city, setCity] = useState('')
+  const [maxAge, setMaxAge] = useState('')
+  const [minAge, setMinAge] = useState('')
+  const [gender, setGender] = useState('')
+  const [remark, setRemark] = useState('')
+  const [fillteredData, setFilteredData] = useState<StudentProps[]>([])
+
+  useEffect(() => {
+    if (data) {
+      let result = data
+
+      if (fullName) {
+        result = result.filter((studentData: StudentProps) =>
+          studentData.student.fullName.includes(fullName),
+        )
+      }
+      if (kana) {
+        result = result.filter((studentData: StudentProps) =>
+          studentData.student.kana.includes(kana),
+        )
+      }
+      if (nickName) {
+        result = result.filter((studentData: StudentProps) =>
+          studentData.student.nickName.includes(nickName),
+        )
+      }
+      if (email) {
+        result = result.filter((studentData: StudentProps) =>
+          studentData.student.email.includes(email),
+        )
+      }
+      if (city) {
+        result = result.filter((studentData: StudentProps) =>
+          studentData.student.city.includes(city),
+        )
+      }
+      if (gender) {
+        result = result.filter((studentData: StudentProps) =>
+          studentData.student.gender.includes(gender),
+        )
+      }
+      if (remark) {
+        result = result.filter((studentData: StudentProps) =>
+          studentData.student.remark.includes(remark),
+        )
+      }
+      if (maxAge) {
+        result = result.filter(
+          (studentData: StudentProps) =>
+            studentData.student.age <= Number(maxAge),
+        )
+      }
+      if (minAge) {
+        result = result.filter(
+          (studentData: StudentProps) =>
+            studentData.student.age >= Number(minAge),
+        )
+      }
+      setFilteredData(result)
+    }
+  }, [
+    data,
+    fullName,
+    kana,
+    nickName,
+    email,
+    city,
+    maxAge,
+    minAge,
+    gender,
+    remark,
+  ])
 
   if (error) return <div>An error has occurred.</div>
   if (!data) return <div>Loading...</div>
 
-  const studentsData = data
+  const handleInputChange =
+    (setter: React.Dispatch<React.SetStateAction<string>>) =>
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      setter(event.target.value)
+    }
+
+  const handleReset = () => {
+    setFullName('')
+    setKana('')
+    setNickName('')
+    setEmail('')
+    setCity('')
+    setMaxAge('')
+    setMinAge('')
+    setGender('')
+    setRemark('')
+  }
 
   return (
     <Box sx={{ backgroundColor: '#f9f9f9', minHeight: '100vh', py: 4 }}>
@@ -54,6 +150,69 @@ const StudentPage: NextPage = () => {
         <Typography variant="h4" gutterBottom>
           受講生一覧
         </Typography>
+
+        <Stack direction="row" spacing={2}>
+          <TextField
+            label="氏名"
+            value={fullName}
+            variant="outlined"
+            onChange={handleInputChange(setFullName)}
+          />
+          <TextField
+            label="カナ名"
+            value={kana}
+            variant="outlined"
+            onChange={handleInputChange(setKana)}
+          />
+          <TextField
+            label="ニックネーム"
+            value={nickName}
+            variant="outlined"
+            onChange={handleInputChange(setNickName)}
+          />
+          <TextField
+            label="メールアドレス"
+            value={email}
+            variant="outlined"
+            onChange={handleInputChange(setEmail)}
+          />
+          <TextField
+            label="居住地域"
+            value={city}
+            variant="outlined"
+            onChange={handleInputChange(setCity)}
+          />
+        </Stack>
+
+        <Stack direction="row" spacing={2} sx={{ mt: 1, mb: 1 }}>
+          <TextField
+            label="最大年齢"
+            value={maxAge}
+            variant="outlined"
+            onChange={handleInputChange(setMaxAge)}
+          />
+          <TextField
+            label="最小年齢"
+            value={minAge}
+            variant="outlined"
+            onChange={handleInputChange(setMinAge)}
+          />
+          <TextField
+            label="性別"
+            value={gender}
+            variant="outlined"
+            onChange={handleInputChange(setGender)}
+          />
+          <TextField
+            label="備考"
+            value={remark}
+            variant="outlined"
+            onChange={handleInputChange(setRemark)}
+          />
+          <Button variant="contained" onClick={handleReset}>
+            リセット
+          </Button>
+        </Stack>
 
         <TableContainer component={Paper}>
           <Table sx={{ minWidth: 650 }} aria-label="simple table">
@@ -70,7 +229,7 @@ const StudentPage: NextPage = () => {
               </TableRow>
             </TableHead>
             <TableBody>
-              {studentsData.map((studentData: StudentProps) => (
+              {fillteredData.map((studentData: StudentProps) => (
                 <TableRow
                   key={studentData.student.id}
                   sx={{ '&:last-child td, &:last-child th': { border: 0 } }}


### PR DESCRIPTION
## 変更の概要
- バックエンドAPIを経由して受講生一覧を表示するUIを作成
- 絞り込み機能を実装し、条件を指定して絞り込みが可能です

**修正が必要な点**
- 各絞り込み用のフォームにバリデーションを実装
- 各行から受講生詳細画面へ遷移できるように修正

## なぜこの変更をするのか

* 変更をする理由
* 前提知識がなくても分かるようにする

## 変更内容
![レコーディング-2025-01-02-105612](https://github.com/user-attachments/assets/f3473f21-9ff9-46a9-ab81-0ab7c2826ca4)


## どうやるのか
- 画面描画時に全データを一覧表示します
- 各入力フォームの入力内容がリアルタイムで絞り込みに反映されます
- リセットボタンを押下すると全データの一覧表示に戻ります

## 備考
この画面上で新規受講生登録ができるようにボタンとモーダル画面を追加予定です