### PR TITLE
feat: 受講生新規登録機能を実装しました

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,6 +19,7 @@
         "next": "15.1.3",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-hook-form": "^7.54.2",
         "swr": "^2.3.0"
       },
       "devDependencies": {
@@ -5154,6 +5155,22 @@
       },
       "peerDependencies": {
         "react": "^19.0.0"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.54.2",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.54.2.tgz",
+      "integrity": "sha512-eHpAUgUjWbZocoQYUHposymRb4ZP6d0uwUnooL2uOybA9/3tPUvoAKqEWK1WaSiTxxOfTpffNZP7QwlnM3/gEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-is": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
     "next": "15.1.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-hook-form": "^7.54.2",
     "swr": "^2.3.0"
   },
   "devDependencies": {

--- a/frontend/src/components/RegisterForm.tsx
+++ b/frontend/src/components/RegisterForm.tsx
@@ -8,7 +8,6 @@ import {
   MenuItem,
   Select,
   TextField,
-  Typography,
 } from '@mui/material'
 
 import { Control, Controller } from 'react-hook-form'
@@ -88,10 +87,6 @@ const RegisterForm: React.FC<RegisterFormProps> = ({
   }
   return (
     <Box sx={{ m: 2 }}>
-      <Typography variant="h5" gutterBottom>
-        新規受講生登録
-      </Typography>
-
       <Grid2 container component="form" spacing={2}>
         <Grid2 size={6}>
           <Controller

--- a/frontend/src/components/RegisterForm.tsx
+++ b/frontend/src/components/RegisterForm.tsx
@@ -2,6 +2,7 @@ import {
   Box,
   Button,
   FormControl,
+  FormHelperText,
   Grid2,
   InputLabel,
   MenuItem,
@@ -27,6 +28,64 @@ const RegisterForm: React.FC<RegisterFormProps> = ({
   // eslint-disable-next-line react/prop-types
   onClick,
 }) => {
+  const validationRules = {
+    student: {
+      fullName: {
+        required: '氏名は必須です',
+      },
+      kana: {
+        pattern: {
+          // eslint-disable-next-line no-irregular-whitespace
+          value: /^$|^[ァ-ヶー\s　]+$/,
+          message: 'カナ名はカタカナとスペースのみを入力してください',
+        },
+      },
+      email: {
+        required: 'メールアドレスは必須です',
+        pattern: {
+          value: /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/,
+          message: '正しい形式のメールアドレスを入力してください。',
+        },
+      },
+      city: {
+        required: '居住地域は必須です',
+      },
+      age: {
+        min: {
+          value: 0,
+          message: '年齢は0歳以上である必要があります',
+        },
+        max: {
+          value: 150,
+          message: '年齢は150歳以下である必要があります',
+        },
+      },
+      gender: {
+        validate: (value: string) => {
+          return (
+            ['Male', 'Female', 'NON_BINARY', ''].includes(value) ||
+            '性別はMale, Female, NON_BINARY のいずれかを指定してください'
+          )
+        },
+      },
+    },
+    studentCourseList: {
+      courseName: {
+        required: 'コース名は必須です',
+      },
+      enrollmentStatus: {
+        status: {
+          required: '申込状況は必須です',
+          validate: (value: string) => {
+            return (
+              ['仮申込', '本申込', '受講中', '受講終了'].includes(value) ||
+              '申込状況は仮申込, 本申込, 受講中, 受講終了 のいずれかを指定してください'
+            )
+          },
+        },
+      },
+    },
+  }
   return (
     <Box sx={{ m: 2 }}>
       <Typography variant="h5" gutterBottom>
@@ -38,9 +97,12 @@ const RegisterForm: React.FC<RegisterFormProps> = ({
           <Controller
             name="student.fullName"
             control={control}
-            render={({ field }) => (
+            rules={validationRules.student.fullName}
+            render={({ field, fieldState }) => (
               <TextField
                 {...field}
+                error={fieldState.invalid}
+                helperText={fieldState.error?.message}
                 type="text"
                 label="氏名"
                 sx={{ backgroundColor: 'white', width: '100%' }}
@@ -53,9 +115,12 @@ const RegisterForm: React.FC<RegisterFormProps> = ({
           <Controller
             name="student.kana"
             control={control}
-            render={({ field }) => (
+            rules={validationRules.student.kana}
+            render={({ field, fieldState }) => (
               <TextField
                 {...field}
+                error={fieldState.invalid}
+                helperText={fieldState.error?.message}
                 type="text"
                 label="カナ名"
                 sx={{ backgroundColor: 'white', width: '100%' }}
@@ -83,9 +148,12 @@ const RegisterForm: React.FC<RegisterFormProps> = ({
           <Controller
             name="student.email"
             control={control}
-            render={({ field }) => (
+            rules={validationRules.student.email}
+            render={({ field, fieldState }) => (
               <TextField
                 {...field}
+                error={fieldState.invalid}
+                helperText={fieldState.error?.message}
                 type="email"
                 label="メールアドレス"
                 sx={{ backgroundColor: 'white', width: '100%' }}
@@ -98,9 +166,12 @@ const RegisterForm: React.FC<RegisterFormProps> = ({
           <Controller
             name="student.city"
             control={control}
-            render={({ field }) => (
+            rules={validationRules.student.city}
+            render={({ field, fieldState }) => (
               <TextField
                 {...field}
+                error={fieldState.invalid}
+                helperText={fieldState.error?.message}
                 type="text"
                 label="居住地域"
                 sx={{ backgroundColor: 'white', width: '100%' }}
@@ -113,9 +184,12 @@ const RegisterForm: React.FC<RegisterFormProps> = ({
           <Controller
             name="student.age"
             control={control}
-            render={({ field }) => (
+            rules={validationRules.student.age}
+            render={({ field, fieldState }) => (
               <TextField
                 {...field}
+                error={fieldState.invalid}
+                helperText={fieldState.error?.message}
                 type="number"
                 label="年齢"
                 sx={{ backgroundColor: 'white', width: '100%' }}
@@ -128,8 +202,9 @@ const RegisterForm: React.FC<RegisterFormProps> = ({
           <Controller
             name="student.gender"
             control={control}
-            render={({ field }) => (
-              <FormControl sx={{ width: '100%' }}>
+            rules={validationRules.student.gender}
+            render={({ field, fieldState }) => (
+              <FormControl sx={{ width: '100%' }} error={fieldState.invalid}>
                 <InputLabel id="gender">性別</InputLabel>
 
                 <Select {...field} labelId="gender" label="gender">
@@ -139,6 +214,7 @@ const RegisterForm: React.FC<RegisterFormProps> = ({
 
                   <MenuItem value={'NON_BINARY'}>NON_BINARY</MenuItem>
                 </Select>
+                <FormHelperText>{fieldState.error?.message}</FormHelperText>
               </FormControl>
             )}
           />
@@ -148,9 +224,12 @@ const RegisterForm: React.FC<RegisterFormProps> = ({
           <Controller
             name={`studentCourseList.${0}.courseName`}
             control={control}
-            render={({ field }) => (
+            rules={validationRules.studentCourseList.courseName}
+            render={({ field, fieldState }) => (
               <TextField
                 {...field}
+                error={fieldState.invalid}
+                helperText={fieldState.error?.message}
                 type="text"
                 label="コース名"
                 sx={{ backgroundColor: 'white', width: '100%' }}
@@ -163,19 +242,18 @@ const RegisterForm: React.FC<RegisterFormProps> = ({
           <Controller
             name={`studentCourseList.${0}.enrollmentStatus.status`}
             control={control}
-            render={({ field }) => (
-              <FormControl sx={{ width: '100%' }}>
+            rules={validationRules.studentCourseList.enrollmentStatus.status}
+            render={({ field, fieldState }) => (
+              <FormControl sx={{ width: '100%' }} error={fieldState.invalid}>
                 <InputLabel id="status">申込状況</InputLabel>
 
                 <Select {...field} labelId="status" label="status">
                   <MenuItem value={'仮申込'}>仮申込</MenuItem>
-
                   <MenuItem value={'本申込'}>本申込</MenuItem>
-
                   <MenuItem value={'受講中'}>受講中</MenuItem>
-
                   <MenuItem value={'受講終了'}>受講終了</MenuItem>
                 </Select>
+                <FormHelperText>{fieldState.error?.message}</FormHelperText>
               </FormControl>
             )}
           />

--- a/frontend/src/components/RegisterForm.tsx
+++ b/frontend/src/components/RegisterForm.tsx
@@ -1,0 +1,213 @@
+import {
+  Box,
+  Button,
+  FormControl,
+  Grid2,
+  InputLabel,
+  MenuItem,
+  Select,
+  TextField,
+  Typography,
+} from '@mui/material'
+
+import { Control, Controller } from 'react-hook-form'
+
+type RegisterFormProps = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  control: Control<any>
+  onSubmit: () => void
+  onClick: () => void
+}
+
+const RegisterForm: React.FC<RegisterFormProps> = ({
+  // eslint-disable-next-line react/prop-types
+  control,
+  // eslint-disable-next-line react/prop-types
+  onSubmit,
+  // eslint-disable-next-line react/prop-types
+  onClick,
+}) => {
+  return (
+    <Box sx={{ m: 2 }}>
+      <Typography variant="h5" gutterBottom>
+        新規受講生登録
+      </Typography>
+
+      <Grid2 container component="form" spacing={2}>
+        <Grid2 size={6}>
+          <Controller
+            name="student.fullName"
+            control={control}
+            render={({ field }) => (
+              <TextField
+                {...field}
+                type="text"
+                label="氏名"
+                sx={{ backgroundColor: 'white', width: '100%' }}
+              />
+            )}
+          />
+        </Grid2>
+
+        <Grid2 size={6}>
+          <Controller
+            name="student.kana"
+            control={control}
+            render={({ field }) => (
+              <TextField
+                {...field}
+                type="text"
+                label="カナ名"
+                sx={{ backgroundColor: 'white', width: '100%' }}
+              />
+            )}
+          />
+        </Grid2>
+
+        <Grid2 size={6}>
+          <Controller
+            name="student.nickName"
+            control={control}
+            render={({ field }) => (
+              <TextField
+                {...field}
+                type="text"
+                label="ニックネーム"
+                sx={{ backgroundColor: 'white', width: '100%' }}
+              />
+            )}
+          />
+        </Grid2>
+
+        <Grid2 size={6}>
+          <Controller
+            name="student.email"
+            control={control}
+            render={({ field }) => (
+              <TextField
+                {...field}
+                type="email"
+                label="メールアドレス"
+                sx={{ backgroundColor: 'white', width: '100%' }}
+              />
+            )}
+          />
+        </Grid2>
+
+        <Grid2 size={6}>
+          <Controller
+            name="student.city"
+            control={control}
+            render={({ field }) => (
+              <TextField
+                {...field}
+                type="text"
+                label="居住地域"
+                sx={{ backgroundColor: 'white', width: '100%' }}
+              />
+            )}
+          />
+        </Grid2>
+
+        <Grid2 size={6}>
+          <Controller
+            name="student.age"
+            control={control}
+            render={({ field }) => (
+              <TextField
+                {...field}
+                type="number"
+                label="年齢"
+                sx={{ backgroundColor: 'white', width: '100%' }}
+              />
+            )}
+          />
+        </Grid2>
+
+        <Grid2 size={4}>
+          <Controller
+            name="student.gender"
+            control={control}
+            render={({ field }) => (
+              <FormControl sx={{ width: '100%' }}>
+                <InputLabel id="gender">性別</InputLabel>
+
+                <Select {...field} labelId="gender" label="gender">
+                  <MenuItem value={'Male'}>Male</MenuItem>
+
+                  <MenuItem value={'Female'}>Female</MenuItem>
+
+                  <MenuItem value={'NON_BINARY'}>NON_BINARY</MenuItem>
+                </Select>
+              </FormControl>
+            )}
+          />
+        </Grid2>
+
+        <Grid2 size={4}>
+          <Controller
+            name={`studentCourseList.${0}.courseName`}
+            control={control}
+            render={({ field }) => (
+              <TextField
+                {...field}
+                type="text"
+                label="コース名"
+                sx={{ backgroundColor: 'white', width: '100%' }}
+              />
+            )}
+          />
+        </Grid2>
+
+        <Grid2 size={4}>
+          <Controller
+            name={`studentCourseList.${0}.enrollmentStatus.status`}
+            control={control}
+            render={({ field }) => (
+              <FormControl sx={{ width: '100%' }}>
+                <InputLabel id="status">申込状況</InputLabel>
+
+                <Select {...field} labelId="status" label="status">
+                  <MenuItem value={'仮申込'}>仮申込</MenuItem>
+
+                  <MenuItem value={'本申込'}>本申込</MenuItem>
+
+                  <MenuItem value={'受講中'}>受講中</MenuItem>
+
+                  <MenuItem value={'受講終了'}>受講終了</MenuItem>
+                </Select>
+              </FormControl>
+            )}
+          />
+        </Grid2>
+
+        <Grid2 size={6}>
+          <Button
+            variant="contained"
+            type="button"
+            size="large"
+            onClick={onSubmit}
+            sx={{ fontWeight: 'bold', color: 'white', width: '100%' }}
+          >
+            登録
+          </Button>
+        </Grid2>
+
+        <Grid2 size={6}>
+          <Button
+            variant="contained"
+            type="button"
+            color="error"
+            size="large"
+            onClick={onClick}
+            sx={{ fontWeight: 'bold', color: 'white', width: '100%' }}
+          >
+            キャンセル
+          </Button>
+        </Grid2>
+      </Grid2>
+    </Box>
+  )
+}
+
+export default RegisterForm

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -3,10 +3,10 @@ import {
   Button,
   Container,
   FormControl,
+  Grid2,
   InputLabel,
   MenuItem,
   Select,
-  Stack,
   TextField,
   Typography,
 } from '@mui/material'
@@ -172,133 +172,168 @@ const StudentPage: NextPage = () => {
           受講生一覧
         </Typography>
 
-        <Typography variant="h4" gutterBottom>
+        <Typography variant="h5" gutterBottom>
           新規受講生登録
         </Typography>
 
-        <Stack component="form" spacing={3}>
-          <Controller
-            name="student.fullName"
-            control={control}
-            render={({ field }) => (
-              <TextField
-                {...field}
-                type="text"
-                label="氏名"
-                sx={{ backgroundColor: 'white' }}
-              />
-            )}
-          />
-          <Controller
-            name="student.kana"
-            control={control}
-            render={({ field }) => (
-              <TextField
-                {...field}
-                type="text"
-                label="カナ名"
-                sx={{ backgroundColor: 'white' }}
-              />
-            )}
-          />
-          <Controller
-            name="student.nickName"
-            control={control}
-            render={({ field }) => (
-              <TextField
-                {...field}
-                type="text"
-                label="ニックネーム"
-                sx={{ backgroundColor: 'white' }}
-              />
-            )}
-          />
-          <Controller
-            name="student.email"
-            control={control}
-            render={({ field }) => (
-              <TextField
-                {...field}
-                type="email"
-                label="メールアドレス"
-                sx={{ backgroundColor: 'white' }}
-              />
-            )}
-          />
-          <Controller
-            name="student.city"
-            control={control}
-            render={({ field }) => (
-              <TextField
-                {...field}
-                type="text"
-                label="居住地域"
-                sx={{ backgroundColor: 'white' }}
-              />
-            )}
-          />
-          <Controller
-            name="student.age"
-            control={control}
-            render={({ field }) => (
-              <TextField
-                {...field}
-                type="number"
-                label="年齢"
-                sx={{ backgroundColor: 'white' }}
-              />
-            )}
-          />
-          <Controller
-            name="student.gender"
-            control={control}
-            render={({ field }) => (
-              <FormControl sx={{ minWidth: 120 }}>
-                <InputLabel id="gender">性別</InputLabel>
-                <Select {...field} labelId="gender" label="gender">
-                  <MenuItem value={'Male'}>Male</MenuItem>
-                  <MenuItem value={'Female'}>Female</MenuItem>
-                  <MenuItem value={'NON_BINARY'}>NON_BINARY</MenuItem>
-                </Select>
-              </FormControl>
-            )}
-          />
-          <Controller
-            name={`studentCourseList.${0}.courseName`}
-            control={control}
-            render={({ field }) => (
-              <TextField
-                {...field}
-                type="text"
-                label="コース名"
-                sx={{ backgroundColor: 'white' }}
-              />
-            )}
-          />
-          <Controller
-            name={`studentCourseList.${0}.enrollmentStatus.status`}
-            control={control}
-            render={({ field }) => (
-              <FormControl sx={{ minWidth: 120 }}>
-                <InputLabel id="status">申込状況</InputLabel>
-                <Select {...field} labelId="status" label="status">
-                  <MenuItem value={'仮申込'}>仮申込</MenuItem>
-                  <MenuItem value={'本申込'}>本申込</MenuItem>
-                  <MenuItem value={'受講中'}>受講中</MenuItem>
-                  <MenuItem value={'受講終了'}>受講終了</MenuItem>
-                </Select>
-              </FormControl>
-            )}
-          />
-          <Button
-            variant="contained"
-            type="button"
-            onClick={handleSubmit(onSubmit)}
-            sx={{ fontWeight: 'bold', color: 'white' }}
-          >
-            送信する
-          </Button>
-        </Stack>
+        <Grid2 container component="form" spacing={2}>
+          <Grid2 size={6}>
+            <Controller
+              name="student.fullName"
+              control={control}
+              render={({ field }) => (
+                <TextField
+                  {...field}
+                  type="text"
+                  label="氏名"
+                  sx={{ backgroundColor: 'white', width: '100%' }}
+                />
+              )}
+            />
+          </Grid2>
+          <Grid2 size={6}>
+            <Controller
+              name="student.kana"
+              control={control}
+              render={({ field }) => (
+                <TextField
+                  {...field}
+                  type="text"
+                  label="カナ名"
+                  sx={{ backgroundColor: 'white', width: '100%' }}
+                />
+              )}
+            />
+          </Grid2>
+          <Grid2 size={6}>
+            <Controller
+              name="student.nickName"
+              control={control}
+              render={({ field }) => (
+                <TextField
+                  {...field}
+                  type="text"
+                  label="ニックネーム"
+                  sx={{ backgroundColor: 'white', width: '100%' }}
+                />
+              )}
+            />
+          </Grid2>
+
+          <Grid2 size={6}>
+            <Controller
+              name="student.email"
+              control={control}
+              render={({ field }) => (
+                <TextField
+                  {...field}
+                  type="email"
+                  label="メールアドレス"
+                  sx={{ backgroundColor: 'white', width: '100%' }}
+                />
+              )}
+            />
+          </Grid2>
+          <Grid2 size={6}>
+            <Controller
+              name="student.city"
+              control={control}
+              render={({ field }) => (
+                <TextField
+                  {...field}
+                  type="text"
+                  label="居住地域"
+                  sx={{ backgroundColor: 'white', width: '100%' }}
+                />
+              )}
+            />
+          </Grid2>
+
+          <Grid2 size={6}>
+            <Controller
+              name="student.age"
+              control={control}
+              render={({ field }) => (
+                <TextField
+                  {...field}
+                  type="number"
+                  label="年齢"
+                  sx={{ backgroundColor: 'white', width: '100%' }}
+                />
+              )}
+            />
+          </Grid2>
+          <Grid2 size={4}>
+            <Controller
+              name="student.gender"
+              control={control}
+              render={({ field }) => (
+                <FormControl sx={{ width: '100%' }}>
+                  <InputLabel id="gender">性別</InputLabel>
+                  <Select {...field} labelId="gender" label="gender">
+                    <MenuItem value={'Male'}>Male</MenuItem>
+                    <MenuItem value={'Female'}>Female</MenuItem>
+                    <MenuItem value={'NON_BINARY'}>NON_BINARY</MenuItem>
+                  </Select>
+                </FormControl>
+              )}
+            />
+          </Grid2>
+          <Grid2 size={4}>
+            <Controller
+              name={`studentCourseList.${0}.courseName`}
+              control={control}
+              render={({ field }) => (
+                <TextField
+                  {...field}
+                  type="text"
+                  label="コース名"
+                  sx={{ backgroundColor: 'white', width: '100%' }}
+                />
+              )}
+            />
+          </Grid2>
+          <Grid2 size={4}>
+            <Controller
+              name={`studentCourseList.${0}.enrollmentStatus.status`}
+              control={control}
+              render={({ field }) => (
+                <FormControl sx={{ width: '100%' }}>
+                  <InputLabel id="status">申込状況</InputLabel>
+                  <Select {...field} labelId="status" label="status">
+                    <MenuItem value={'仮申込'}>仮申込</MenuItem>
+                    <MenuItem value={'本申込'}>本申込</MenuItem>
+                    <MenuItem value={'受講中'}>受講中</MenuItem>
+                    <MenuItem value={'受講終了'}>受講終了</MenuItem>
+                  </Select>
+                </FormControl>
+              )}
+            />
+          </Grid2>
+          <Grid2 size={6}>
+            <Button
+              variant="contained"
+              type="button"
+              size="large"
+              onClick={handleSubmit(onSubmit)}
+              sx={{ fontWeight: 'bold', color: 'white', width: '100%' }}
+            >
+              登録
+            </Button>
+          </Grid2>
+          <Grid2 size={6}>
+            <Button
+              variant="contained"
+              type="button"
+              color="error"
+              size="large"
+              onClick={handleSubmit(onSubmit)}
+              sx={{ fontWeight: 'bold', color: 'white', width: '100%' }}
+            >
+              キャンセル
+            </Button>
+          </Grid2>
+        </Grid2>
 
         <FilterInputs
           fullName={fullName}

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -32,7 +32,7 @@ export type StudentProps = {
 }
 
 const StudentPage: NextPage = () => {
-  const url = 'http://localhost:8080/students'
+  const url = process.env.NEXT_PUBLIC_API_BASE_URL + '/students'
   const { data, error } = useSWR(url, fetcher)
   const [fullName, setFullName] = useState('')
   const [kana, setKana] = useState('')

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -212,7 +212,7 @@ const StudentPage: NextPage = () => {
           onClick={handleClickOpen}
           sx={{ mt: 2, mb: 2, textAlign: 'center' }}
         >
-          <Button variant="contained">受講生新規登録</Button>
+          <Button variant="contained">新規登録</Button>
         </Box>
 
         <StudentTable data={filteredData} />

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -2,20 +2,17 @@ import {
   Box,
   Button,
   Container,
-  FormControl,
-  Grid2,
-  InputLabel,
-  MenuItem,
-  Select,
-  TextField,
+  Dialog,
+  DialogTitle,
   Typography,
 } from '@mui/material'
 import axios, { AxiosError, AxiosResponse } from 'axios'
 import type { NextPage } from 'next'
 import { useEffect, useState } from 'react'
-import { Controller, SubmitHandler, useForm } from 'react-hook-form'
+import { SubmitHandler, useForm } from 'react-hook-form'
 import useSWR from 'swr'
 import FilterInputs from '@/components/FilterInputs'
+import RegisterForm from '@/components/RegisterForm'
 import StudentTable from '@/components/StudentTable'
 import { fetcher } from '@/utils'
 
@@ -57,6 +54,7 @@ const StudentPage: NextPage = () => {
   const [gender, setGender] = useState('')
   const [remark, setRemark] = useState('')
   const [filteredData, setFilteredData] = useState<StudentDetailProps[]>([])
+  const [open, setOpen] = useState(false)
   const { control, handleSubmit, reset } = useForm<StudentDetailProps>({
     defaultValues: {
       student: {
@@ -66,7 +64,7 @@ const StudentPage: NextPage = () => {
         nickName: '',
         email: '',
         city: '',
-        age: undefined,
+        age: 0,
         gender: '',
       },
       studentCourseList: [
@@ -153,13 +151,22 @@ const StudentPage: NextPage = () => {
     axios({ method: 'POST', url: url, data: data, headers: headers })
       .then((res: AxiosResponse) => {
         res.status === 200 && mutate()
-        reset()
+        handleClickClose()
         alert(res.data.student.fullName + 'さんを登録しました')
       })
       .catch((err: AxiosError<{ error: string }>) => {
         console.log(err.message)
         alert(err.message)
       })
+  }
+
+  const handleClickOpen = () => {
+    setOpen(true)
+  }
+
+  const handleClickClose = () => {
+    setOpen(false)
+    reset()
   }
 
   if (error) return <div>An error has occurred.</div>
@@ -172,168 +179,14 @@ const StudentPage: NextPage = () => {
           受講生一覧
         </Typography>
 
-        <Typography variant="h5" gutterBottom>
-          新規受講生登録
-        </Typography>
-
-        <Grid2 container component="form" spacing={2}>
-          <Grid2 size={6}>
-            <Controller
-              name="student.fullName"
-              control={control}
-              render={({ field }) => (
-                <TextField
-                  {...field}
-                  type="text"
-                  label="氏名"
-                  sx={{ backgroundColor: 'white', width: '100%' }}
-                />
-              )}
-            />
-          </Grid2>
-          <Grid2 size={6}>
-            <Controller
-              name="student.kana"
-              control={control}
-              render={({ field }) => (
-                <TextField
-                  {...field}
-                  type="text"
-                  label="カナ名"
-                  sx={{ backgroundColor: 'white', width: '100%' }}
-                />
-              )}
-            />
-          </Grid2>
-          <Grid2 size={6}>
-            <Controller
-              name="student.nickName"
-              control={control}
-              render={({ field }) => (
-                <TextField
-                  {...field}
-                  type="text"
-                  label="ニックネーム"
-                  sx={{ backgroundColor: 'white', width: '100%' }}
-                />
-              )}
-            />
-          </Grid2>
-
-          <Grid2 size={6}>
-            <Controller
-              name="student.email"
-              control={control}
-              render={({ field }) => (
-                <TextField
-                  {...field}
-                  type="email"
-                  label="メールアドレス"
-                  sx={{ backgroundColor: 'white', width: '100%' }}
-                />
-              )}
-            />
-          </Grid2>
-          <Grid2 size={6}>
-            <Controller
-              name="student.city"
-              control={control}
-              render={({ field }) => (
-                <TextField
-                  {...field}
-                  type="text"
-                  label="居住地域"
-                  sx={{ backgroundColor: 'white', width: '100%' }}
-                />
-              )}
-            />
-          </Grid2>
-
-          <Grid2 size={6}>
-            <Controller
-              name="student.age"
-              control={control}
-              render={({ field }) => (
-                <TextField
-                  {...field}
-                  type="number"
-                  label="年齢"
-                  sx={{ backgroundColor: 'white', width: '100%' }}
-                />
-              )}
-            />
-          </Grid2>
-          <Grid2 size={4}>
-            <Controller
-              name="student.gender"
-              control={control}
-              render={({ field }) => (
-                <FormControl sx={{ width: '100%' }}>
-                  <InputLabel id="gender">性別</InputLabel>
-                  <Select {...field} labelId="gender" label="gender">
-                    <MenuItem value={'Male'}>Male</MenuItem>
-                    <MenuItem value={'Female'}>Female</MenuItem>
-                    <MenuItem value={'NON_BINARY'}>NON_BINARY</MenuItem>
-                  </Select>
-                </FormControl>
-              )}
-            />
-          </Grid2>
-          <Grid2 size={4}>
-            <Controller
-              name={`studentCourseList.${0}.courseName`}
-              control={control}
-              render={({ field }) => (
-                <TextField
-                  {...field}
-                  type="text"
-                  label="コース名"
-                  sx={{ backgroundColor: 'white', width: '100%' }}
-                />
-              )}
-            />
-          </Grid2>
-          <Grid2 size={4}>
-            <Controller
-              name={`studentCourseList.${0}.enrollmentStatus.status`}
-              control={control}
-              render={({ field }) => (
-                <FormControl sx={{ width: '100%' }}>
-                  <InputLabel id="status">申込状況</InputLabel>
-                  <Select {...field} labelId="status" label="status">
-                    <MenuItem value={'仮申込'}>仮申込</MenuItem>
-                    <MenuItem value={'本申込'}>本申込</MenuItem>
-                    <MenuItem value={'受講中'}>受講中</MenuItem>
-                    <MenuItem value={'受講終了'}>受講終了</MenuItem>
-                  </Select>
-                </FormControl>
-              )}
-            />
-          </Grid2>
-          <Grid2 size={6}>
-            <Button
-              variant="contained"
-              type="button"
-              size="large"
-              onClick={handleSubmit(onSubmit)}
-              sx={{ fontWeight: 'bold', color: 'white', width: '100%' }}
-            >
-              登録
-            </Button>
-          </Grid2>
-          <Grid2 size={6}>
-            <Button
-              variant="contained"
-              type="button"
-              color="error"
-              size="large"
-              onClick={handleSubmit(onSubmit)}
-              sx={{ fontWeight: 'bold', color: 'white', width: '100%' }}
-            >
-              キャンセル
-            </Button>
-          </Grid2>
-        </Grid2>
+        <Dialog open={open} onClose={handleClickClose}>
+          <DialogTitle>新規受講生登録</DialogTitle>
+          <RegisterForm
+            control={control}
+            onSubmit={handleSubmit(onSubmit)}
+            onClick={handleClickClose}
+          />
+        </Dialog>
 
         <FilterInputs
           fullName={fullName}
@@ -355,6 +208,12 @@ const StudentPage: NextPage = () => {
           remark={remark}
           setRemark={setRemark}
         />
+        <Box
+          onClick={handleClickOpen}
+          sx={{ mt: 2, mb: 2, textAlign: 'center' }}
+        >
+          <Button variant="contained">受講生新規登録</Button>
+        </Box>
 
         <StudentTable data={filteredData} />
       </Container>


### PR DESCRIPTION
## 変更の概要
- 受講生新規登録機能を実装しました
  - 一覧画面から登録用ボタンを押下し、ダイアログ表示としてフォームを表示
  - フォームからリクエストを送信
  - バリデーション実装済

## なぜこの変更をするのか
画面からバックエンドAPI経由でDBに新規レコードを挿入できるようにするため

## 変更内容
![無題の動画-‐-Clipchampで作成-_2_](https://github.com/user-attachments/assets/f5fa64d5-0b1a-4268-b549-8ed7296c0d53)

## どうやるのか
- 登録
  - 一覧画面から新規登録ボタンを押下
  - 表示されるフォームに内容を入力
    - カナ、ニックネーム、性別、年齢は非必須
  - 入力後、登録ボタンを押下するとリクエストが飛ぶ
  - 成功するとウィンドウアラートが表示され、一覧画面に戻る

- バリデーション
  - 未入力状態で登録ボタンを押下すると必須項目のバリデーションが確認できます
  - その他のバリデーションは以下のとおりです
    - メールアドレス: 正規表現
    - カナ名：正規表現
    - 年齢：最小0, 最大150

