### PR TITLE
feat: 受講生詳細画面の実装を行いました

### DIFF
--- a/frontend/src/components/StudentTable.tsx
+++ b/frontend/src/components/StudentTable.tsx
@@ -1,43 +1,28 @@
 import {
   Box,
   Button,
-  Checkbox,
-  FormControl,
-  FormControlLabel,
-  FormHelperText,
-  Grid2,
-  InputLabel,
-  MenuItem,
   Paper,
-  Select,
   Table,
   TableBody,
   TableCell,
   TableContainer,
   TableHead,
   TableRow,
-  TextField,
 } from '@mui/material'
 import React from 'react'
-import { Controller, useForm, UseFormReturn } from 'react-hook-form'
+import { UseFormReturn } from 'react-hook-form'
 import { StudentDetailProps } from '@/pages'
-import { Check, CheckBox } from '@mui/icons-material';
-import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
-import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
-import { DatePicker } from '@mui/x-date-pickers/DatePicker';
-import UpdateForm from './UpdateForm';
 
 type StudentTableProps = {
-  data: StudentDetailProps[];
+  data: StudentDetailProps[]
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   updateForm: UseFormReturn<StudentDetailProps, any, undefined>
-  deleteStudent: (studentDetail: StudentDetailProps) => void;
-};
+  deleteStudent: (studentDetail: StudentDetailProps) => void
+}
 
-const StudentTable: React.FC<StudentTableProps> = ({ data, deleteStudent, updateForm }) => {
-
+const StudentTable: React.FC<StudentTableProps> = ({ data, deleteStudent }) => {
   return (
     <Box>
-
       <TableContainer component={Paper}>
         <Table sx={{ minWidth: 650 }} aria-label="simple table">
           <TableHead>
@@ -65,7 +50,12 @@ const StudentTable: React.FC<StudentTableProps> = ({ data, deleteStudent, update
                 <TableCell>{studentData.student.gender}</TableCell>
                 <TableCell>{studentData.student.remark}</TableCell>
                 <TableCell>
-                  <Button variant="contained" color='error' size="small" onClick={() => deleteStudent(studentData)}>
+                  <Button
+                    variant="contained"
+                    color="error"
+                    size="small"
+                    onClick={() => deleteStudent(studentData)}
+                  >
                     削除
                   </Button>
                 </TableCell>

--- a/frontend/src/components/StudentTable.tsx
+++ b/frontend/src/components/StudentTable.tsx
@@ -9,6 +9,7 @@ import {
   TableHead,
   TableRow,
 } from '@mui/material'
+import router from 'next/router'
 import React from 'react'
 import { UseFormReturn } from 'react-hook-form'
 import { StudentDetailProps } from '@/pages'
@@ -40,7 +41,13 @@ const StudentTable: React.FC<StudentTableProps> = ({ data, deleteStudent }) => {
           </TableHead>
           <TableBody>
             {data.map((studentData) => (
-              <TableRow key={studentData.student.id}>
+              <TableRow
+                key={studentData.student.id}
+                onClick={() =>
+                  router.push(`/students/${studentData.student.id}`)
+                }
+                style={{ cursor: 'pointer' }}
+              >
                 <TableCell>{studentData.student.fullName}</TableCell>
                 <TableCell>{studentData.student.kana}</TableCell>
                 <TableCell>{studentData.student.nickName}</TableCell>

--- a/frontend/src/components/UpdateForm.tsx
+++ b/frontend/src/components/UpdateForm.tsx
@@ -1,0 +1,296 @@
+import {
+  Grid2,
+  TextField,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  FormHelperText,
+  FormControlLabel,
+  Checkbox,
+  Button,
+} from '@mui/material'
+
+import { Controller, UseFormReturn } from 'react-hook-form'
+
+import { StudentDetailProps } from '@/pages'
+
+type updateFormProps = {
+  studentData: StudentDetailProps
+
+  updateForm: UseFormReturn<StudentDetailProps, any, undefined>
+}
+
+const UpdateForm: React.FC<updateFormProps> = ({ studentData, updateForm }) => {
+  const control = updateForm.control
+
+  return (
+    <Grid2 container component="form" spacing={2}>
+      <Grid2 size={6}>
+        <Controller
+          name="student.id"
+          control={control}
+          render={({ field, fieldState }) => (
+            <TextField
+              {...field}
+              error={fieldState.invalid}
+              helperText={fieldState.error?.message}
+              type="text"
+              label="id"
+              sx={{ backgroundColor: 'white', width: '100%' }}
+            />
+          )}
+        />
+      </Grid2>
+
+      <Grid2 size={6}>
+        <Controller
+          name="student.fullName"
+          control={control}
+          render={({ field, fieldState }) => (
+            <TextField
+              {...field}
+              error={fieldState.invalid}
+              helperText={fieldState.error?.message}
+              type="text"
+              label="氏名"
+              sx={{ backgroundColor: 'white', width: '100%' }}
+            />
+          )}
+        />
+      </Grid2>
+
+      <Grid2 size={6}>
+        <Controller
+          name="student.kana"
+          control={control}
+          render={({ field, fieldState }) => (
+            <TextField
+              {...field}
+              error={fieldState.invalid}
+              helperText={fieldState.error?.message}
+              type="text"
+              label="カナ名"
+              sx={{ backgroundColor: 'white', width: '100%' }}
+            />
+          )}
+        />
+      </Grid2>
+
+      <Grid2 size={6}>
+        <Controller
+          name="student.nickName"
+          control={control}
+          render={({ field }) => (
+            <TextField
+              {...field}
+              type="text"
+              label="ニックネーム"
+              sx={{ backgroundColor: 'white', width: '100%' }}
+            />
+          )}
+        />
+      </Grid2>
+
+      <Grid2 size={6}>
+        <Controller
+          name="student.email"
+          control={control}
+          render={({ field, fieldState }) => (
+            <TextField
+              {...field}
+              error={fieldState.invalid}
+              helperText={fieldState.error?.message}
+              type="email"
+              label="メールアドレス"
+              sx={{ backgroundColor: 'white', width: '100%' }}
+            />
+          )}
+        />
+      </Grid2>
+
+      <Grid2 size={6}>
+        <Controller
+          name="student.city"
+          control={control}
+          render={({ field, fieldState }) => (
+            <TextField
+              {...field}
+              error={fieldState.invalid}
+              helperText={fieldState.error?.message}
+              type="text"
+              label="居住地域"
+              sx={{ backgroundColor: 'white', width: '100%' }}
+            />
+          )}
+        />
+      </Grid2>
+
+      <Grid2 size={6}>
+        <Controller
+          name="student.age"
+          control={control}
+          render={({ field, fieldState }) => (
+            <TextField
+              {...field}
+              error={fieldState.invalid}
+              helperText={fieldState.error?.message}
+              type="number"
+              label="年齢"
+              sx={{ backgroundColor: 'white', width: '100%' }}
+            />
+          )}
+        />
+      </Grid2>
+
+      <Grid2 size={4}>
+        <Controller
+          name="student.gender"
+          control={control}
+          render={({ field, fieldState }) => (
+            <FormControl sx={{ width: '100%' }} error={fieldState.invalid}>
+              <InputLabel id="gender">性別</InputLabel>
+
+              <Select {...field} labelId="gender" label="gender">
+                <MenuItem value={'Male'}>Male</MenuItem>
+
+                <MenuItem value={'Female'}>Female</MenuItem>
+
+                <MenuItem value={'NON_BINARY'}>NON_BINARY</MenuItem>
+              </Select>
+
+              <FormHelperText>{fieldState.error?.message}</FormHelperText>
+            </FormControl>
+          )}
+        />
+      </Grid2>
+
+      <Grid2 size={6}>
+        <Controller
+          name="student.remark"
+          control={control}
+          render={({ field, fieldState }) => (
+            <TextField
+              {...field}
+              error={fieldState.invalid}
+              helperText={fieldState.error?.message}
+              type="text"
+              label="備考"
+              sx={{ backgroundColor: 'white', width: '100%' }}
+            />
+          )}
+        />
+      </Grid2>
+
+      <Grid2 size={6}>
+        <Controller
+          name="student.isDeleted"
+          control={control}
+          render={({ field }) => (
+            <FormControlLabel control={<Checkbox {...field} />} label="削除" />
+          )}
+        />
+      </Grid2>
+
+      <Grid2 size={4}>
+        <Controller
+          name={`studentCourseList.${0}.courseName`}
+          control={control}
+          render={({ field, fieldState }) => (
+            <TextField
+              {...field}
+              error={fieldState.invalid}
+              helperText={fieldState.error?.message}
+              type="text"
+              label="コース名"
+              sx={{ backgroundColor: 'white', width: '100%' }}
+            />
+          )}
+        />
+      </Grid2>
+
+      <Grid2 size={4}>
+        <Controller
+          name={`studentCourseList.${0}.startDate`}
+          control={control}
+          render={({ field, fieldState }) => (
+            <TextField
+              {...field}
+              error={fieldState.invalid}
+              helperText={fieldState.error?.message}
+              type="string"
+              label="受講開始日"
+              sx={{ backgroundColor: 'white', width: '100%' }}
+            />
+          )}
+        />
+      </Grid2>
+
+      <Grid2 size={4}>
+        <Controller
+          name={`studentCourseList.${0}.endDate`}
+          control={control}
+          render={({ field, fieldState }) => (
+            <TextField
+              {...field}
+              error={fieldState.invalid}
+              helperText={fieldState.error?.message}
+              type="string"
+              label="受講終了予定日"
+              sx={{ backgroundColor: 'white', width: '100%' }}
+            />
+          )}
+        />
+      </Grid2>
+
+      <Grid2 size={4}>
+        <Controller
+          name={`studentCourseList.${0}.enrollmentStatus.status`}
+          control={control}
+          render={({ field, fieldState }) => (
+            <FormControl sx={{ width: '100%' }} error={fieldState.invalid}>
+              <InputLabel id="status">申込状況</InputLabel>
+
+              <Select {...field} labelId="status" label="status">
+                <MenuItem value={'仮申込'}>仮申込</MenuItem>
+
+                <MenuItem value={'本申込'}>本申込</MenuItem>
+
+                <MenuItem value={'受講中'}>受講中</MenuItem>
+
+                <MenuItem value={'受講終了'}>受講終了</MenuItem>
+              </Select>
+
+              <FormHelperText>{fieldState.error?.message}</FormHelperText>
+            </FormControl>
+          )}
+        />
+      </Grid2>
+
+      <Grid2 size={6}>
+        <Button
+          variant="contained"
+          type="button"
+          size="large"
+          sx={{ fontWeight: 'bold', color: 'white', width: '100%' }}
+        >
+          更新
+        </Button>
+      </Grid2>
+
+      <Grid2 size={6}>
+        <Button
+          variant="contained"
+          type="button"
+          color="error"
+          size="large"
+          sx={{ fontWeight: 'bold', color: 'white', width: '100%' }}
+        >
+          キャンセル
+        </Button>
+      </Grid2>
+    </Grid2>
+  )
+}
+
+export default UpdateForm

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -56,7 +56,7 @@ const StudentPage: NextPage = () => {
   const [remark, setRemark] = useState('')
   const [filteredData, setFilteredData] = useState<StudentDetailProps[]>([])
   const [open, setOpen] = useState(false)
-  const { control, handleSubmit, reset} = useForm<StudentDetailProps>({
+  const { control, handleSubmit, reset } = useForm<StudentDetailProps>({
     defaultValues: {
       student: {
         id: '',
@@ -194,10 +194,10 @@ const StudentPage: NextPage = () => {
 
   const deleteStudent = (studentData: StudentDetailProps) => {
     const confirmDelete = window.confirm(
-      studentData.student.fullName + 'さんを本当に削除してよろしいですか？'
+      studentData.student.fullName + 'さんを本当に削除してよろしいですか？',
     )
 
-    if(!confirmDelete){
+    if (!confirmDelete) {
       return
     }
 
@@ -210,8 +210,10 @@ const StudentPage: NextPage = () => {
     axios({ method: 'PUT', url: url, data: data, headers: headers })
       .then((res: AxiosResponse) => {
         res.status === 200 && mutate()
-        alert(data.student.fullName + 'さんを削除しました\n\n' +
-          'データの復旧を希望の場合は管理者にお問い合わせください'
+        alert(
+          data.student.fullName +
+            'さんを削除しました\n\n' +
+            'データの復旧を希望の場合は管理者にお問い合わせください',
         )
       })
       .catch((err: AxiosError<{ error: string }>) => {
@@ -219,7 +221,6 @@ const StudentPage: NextPage = () => {
         alert(err.message)
       })
   }
-
 
   if (error) return <div>An error has occurred.</div>
   if (!data) return <div>Loading...</div>
@@ -267,7 +268,11 @@ const StudentPage: NextPage = () => {
           <Button variant="contained">新規登録</Button>
         </Box>
 
-        <StudentTable data={filteredData} deleteStudent={deleteStudent} updateForm={updateForm}/>
+        <StudentTable
+          data={filteredData}
+          deleteStudent={deleteStudent}
+          updateForm={updateForm}
+        />
       </Container>
     </Box>
   )

--- a/frontend/src/pages/students/[id].tsx
+++ b/frontend/src/pages/students/[id].tsx
@@ -1,0 +1,115 @@
+import {
+  Box,
+  Container,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+} from '@mui/material'
+import { NextPage } from 'next'
+import { useRouter } from 'next/router'
+import useSWR from 'swr'
+import { fetcher } from '@/utils'
+
+type StudentCourseProps = {
+  id: string
+  courseName: string
+  startDate: string
+  endDate: string
+  enrollmentStatus: {
+    id: string
+    status: string
+    createdAt: string
+  }
+}
+
+const StudentDetail: NextPage = () => {
+  const router = useRouter()
+  const { id } = router.query
+  const url = process.env.NEXT_PUBLIC_API_BASE_URL + '/students/' + id
+  const { data, error, mutate } = useSWR(url, fetcher)
+
+  if (error) return <div>An error has occurred.</div>
+  if (!data) return <div>Loading...</div>
+
+  return (
+    <Box sx={{ backgroundColor: '#f9f9f9', minHeight: '100vh', py: 4 }}>
+      <Container maxWidth="lg">
+        <Typography variant="h4" gutterBottom>
+          受講生詳細
+        </Typography>
+        <Typography variant="h5" gutterBottom>
+          基本情報
+        </Typography>
+        <TableContainer component={Paper} sx={{ mb: 2 }}>
+          <Table sx={{ minWidth: 650 }}>
+            <TableHead>
+              <TableRow>
+                <TableCell>氏名</TableCell>
+                <TableCell>カナ名</TableCell>
+                <TableCell>ニックネーム</TableCell>
+                <TableCell>メールアドレス</TableCell>
+                <TableCell>居住地域</TableCell>
+                <TableCell>年齢</TableCell>
+                <TableCell>性別</TableCell>
+                <TableCell>備考</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              <TableRow key={data.student.id}>
+                <TableCell>{data.student.fullName}</TableCell>
+                <TableCell>{data.student.kana}</TableCell>
+                <TableCell>{data.student.nickName}</TableCell>
+                <TableCell>{data.student.email}</TableCell>
+                <TableCell>{data.student.city}</TableCell>
+                <TableCell>{data.student.age}</TableCell>
+                <TableCell>{data.student.gender}</TableCell>
+                <TableCell>{data.student.remark}</TableCell>
+              </TableRow>
+            </TableBody>
+          </Table>
+        </TableContainer>
+
+        <Typography variant="h5" gutterBottom>
+          受講コース
+        </Typography>
+        <TableContainer component={Paper}>
+          <Table sx={{ minWidth: 650 }}>
+            <TableHead>
+              <TableRow>
+                <TableCell>受講コース名</TableCell>
+                <TableCell>受講開始日</TableCell>
+                <TableCell>受講修了予定日</TableCell>
+                <TableCell>申込状況</TableCell>
+                <TableCell>申込状況更新日時</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {data.studentCourseList.map(
+                (studentCourse: StudentCourseProps) => (
+                  <TableRow key={studentCourse.id}>
+                    <TableCell>{studentCourse.courseName}</TableCell>
+                    <TableCell>{studentCourse.startDate}</TableCell>
+                    <TableCell>{studentCourse.endDate}</TableCell>
+                    <TableCell>
+                      {studentCourse.enrollmentStatus.status}
+                    </TableCell>
+                    <TableCell>
+                      {studentCourse.enrollmentStatus.createdAt}
+                    </TableCell>
+                  </TableRow>
+                ),
+              )}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </Container>
+    </Box>
+  )
+}
+
+export default StudentDetail


### PR DESCRIPTION
## 変更の概要
- 受講生詳細画面の実装を行いました
  - 一覧画面から遷移
  - 氏名などの基本情報を描画
  - 受講生コース状況を一覧で描画

## なぜこの変更をするのか
- 可読性担保のために受講生一覧画面に描画していないコース情報を描画するため
- 更新処理実装の前段階として、任意の受講生情報を持った画面があるとやりやすいため

## 変更内容
![レコーディング-2025-01-04-070728](https://github.com/user-attachments/assets/7bb43fc1-314e-4429-bc7f-98206e777bb7)

## どうやるのか
- 受講生一覧から任意の受講生をクリック
- 受講生詳細画面へ遷移

## 備考
この画面に以下の機能を実装予定です
- 申込状況の変更機能
- 受講生情報の変更機能