### PR TITLE
feat: 更新用画面を実装しました

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -14,6 +14,7 @@
     "react/react-in-jsx-scope": "off",
     "import/order": [2, { "alphabetize": { "order": "asc" } }],
     "import/no-unresolved": "off",
+    "react/prop-types": "off",
     "prettier/prettier": [
       "error",
       {

--- a/frontend/src/components/EditForm.tsx
+++ b/frontend/src/components/EditForm.tsx
@@ -21,7 +21,7 @@ type updateFormProps = {
   onClick: () => void
 }
 
-const UpdateForm: React.FC<updateFormProps> = ({
+const EditForm: React.FC<updateFormProps> = ({
   studentData,
   control,
   onSubmit,
@@ -178,7 +178,7 @@ const UpdateForm: React.FC<updateFormProps> = ({
 
         {studentData.studentCourseList.map((studentCourse, index) => (
           <Grid2 container spacing={2} key={index}>
-            <Grid2 size={4}>
+            <Grid2 size={12}>
               <Controller
                 name={`studentCourseList.${index}.courseName`}
                 control={control}
@@ -195,7 +195,7 @@ const UpdateForm: React.FC<updateFormProps> = ({
               />
             </Grid2>
 
-            <Grid2 size={3}>
+            <Grid2 size={6}>
               <Controller
                 name={`studentCourseList.${index}.startDate`}
                 control={control}
@@ -212,7 +212,7 @@ const UpdateForm: React.FC<updateFormProps> = ({
               />
             </Grid2>
 
-            <Grid2 size={3}>
+            <Grid2 size={6}>
               <Controller
                 name={`studentCourseList.${index}.endDate`}
                 control={control}
@@ -227,24 +227,6 @@ const UpdateForm: React.FC<updateFormProps> = ({
                   />
                 )}
               />
-            </Grid2>
-
-            <Grid2 size={2}>
-              <FormControl sx={{ width: '100%' }}>
-                <InputLabel id="status">申込状況</InputLabel>
-                <Controller
-                  name={`studentCourseList.${index}.enrollmentStatus.status`}
-                  control={control}
-                  render={({ field }) => (
-                    <Select {...field} labelId="status" label="status">
-                      <MenuItem value={'仮申込'}>仮申込</MenuItem>
-                      <MenuItem value={'本申込'}>本申込</MenuItem>
-                      <MenuItem value={'受講中'}>受講中</MenuItem>
-                      <MenuItem value={'受講終了'}>受講終了</MenuItem>
-                    </Select>
-                  )}
-                />
-              </FormControl>
             </Grid2>
           </Grid2>
         ))}
@@ -280,4 +262,4 @@ const UpdateForm: React.FC<updateFormProps> = ({
   )
 }
 
-export default UpdateForm
+export default EditForm

--- a/frontend/src/components/EditForm.tsx
+++ b/frontend/src/components/EditForm.tsx
@@ -18,14 +18,16 @@ type updateFormProps = {
   studentData: StudentDetailProps
   control: Control<StudentDetailProps>
   onSubmit: () => void
-  onClick: () => void
+  onCancel: () => void
+  onReset: () => void
 }
 
 const EditForm: React.FC<updateFormProps> = ({
   studentData,
   control,
   onSubmit,
-  onClick,
+  onCancel,
+  onReset,
 }) => {
   return (
     <Box sx={{ m: 2 }}>
@@ -232,7 +234,7 @@ const EditForm: React.FC<updateFormProps> = ({
         ))}
 
         <Grid2 container spacing={2} sx={{ mt: 3 }}>
-          <Grid2 size={6}>
+          <Grid2 size={4}>
             <Button
               variant="contained"
               type="button"
@@ -244,13 +246,26 @@ const EditForm: React.FC<updateFormProps> = ({
             </Button>
           </Grid2>
 
-          <Grid2 size={6}>
+          <Grid2 size={4}>
             <Button
               variant="contained"
               type="button"
               color="error"
               size="large"
-              onClick={onClick}
+              onClick={onReset}
+              sx={{ fontWeight: 'bold', color: 'white', width: '100%' }}
+            >
+              リセット
+            </Button>
+          </Grid2>
+
+          <Grid2 size={4}>
+            <Button
+              variant="contained"
+              type="button"
+              color="error"
+              size="large"
+              onClick={onCancel}
               sx={{ fontWeight: 'bold', color: 'white', width: '100%' }}
             >
               キャンセル

--- a/frontend/src/components/RegisterForm.tsx
+++ b/frontend/src/components/RegisterForm.tsx
@@ -11,20 +11,17 @@ import {
 } from '@mui/material'
 
 import { Control, Controller } from 'react-hook-form'
+import { StudentDetailProps } from '@/pages'
 
 type RegisterFormProps = {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  control: Control<any>
+  control: Control<StudentDetailProps>
   onSubmit: () => void
   onClick: () => void
 }
 
 const RegisterForm: React.FC<RegisterFormProps> = ({
-  // eslint-disable-next-line react/prop-types
   control,
-  // eslint-disable-next-line react/prop-types
   onSubmit,
-  // eslint-disable-next-line react/prop-types
   onClick,
 }) => {
   const validationRules = {

--- a/frontend/src/components/StudentTable.tsx
+++ b/frontend/src/components/StudentTable.tsx
@@ -11,13 +11,10 @@ import {
 } from '@mui/material'
 import router from 'next/router'
 import React from 'react'
-import { UseFormReturn } from 'react-hook-form'
 import { StudentDetailProps } from '@/pages'
 
 type StudentTableProps = {
   data: StudentDetailProps[]
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  updateForm: UseFormReturn<StudentDetailProps, any, undefined>
   deleteStudent: (studentDetail: StudentDetailProps) => void
 }
 

--- a/frontend/src/components/UpdateForm.tsx
+++ b/frontend/src/components/UpdateForm.tsx
@@ -5,291 +5,278 @@ import {
   InputLabel,
   Select,
   MenuItem,
-  FormHelperText,
-  FormControlLabel,
-  Checkbox,
   Button,
+  Box,
+  Typography,
 } from '@mui/material'
 
-import { Controller, UseFormReturn } from 'react-hook-form'
+import { Control, Controller } from 'react-hook-form'
 
 import { StudentDetailProps } from '@/pages'
 
 type updateFormProps = {
   studentData: StudentDetailProps
-
-  updateForm: UseFormReturn<StudentDetailProps, any, undefined>
+  control: Control<StudentDetailProps>
+  onSubmit: () => void
+  onClick: () => void
 }
 
-const UpdateForm: React.FC<updateFormProps> = ({ studentData, updateForm }) => {
-  const control = updateForm.control
-
+const UpdateForm: React.FC<updateFormProps> = ({
+  studentData,
+  control,
+  onSubmit,
+  onClick,
+}) => {
   return (
-    <Grid2 container component="form" spacing={2}>
-      <Grid2 size={6}>
-        <Controller
-          name="student.id"
-          control={control}
-          render={({ field, fieldState }) => (
-            <TextField
-              {...field}
-              error={fieldState.invalid}
-              helperText={fieldState.error?.message}
-              type="text"
-              label="id"
-              sx={{ backgroundColor: 'white', width: '100%' }}
+    <Box sx={{ m: 2 }}>
+      <form>
+        <Typography variant="h6" gutterBottom>
+          受講生
+        </Typography>
+
+        <Grid2 container spacing={2}>
+          <Grid2 size={6}>
+            <Controller
+              name="student.fullName"
+              control={control}
+              render={({ field, fieldState }) => (
+                <TextField
+                  {...field}
+                  error={fieldState.invalid}
+                  helperText={fieldState.error?.message}
+                  type="text"
+                  label="氏名"
+                  sx={{ backgroundColor: 'white', width: '100%' }}
+                />
+              )}
             />
-          )}
-        />
-      </Grid2>
+          </Grid2>
 
-      <Grid2 size={6}>
-        <Controller
-          name="student.fullName"
-          control={control}
-          render={({ field, fieldState }) => (
-            <TextField
-              {...field}
-              error={fieldState.invalid}
-              helperText={fieldState.error?.message}
-              type="text"
-              label="氏名"
-              sx={{ backgroundColor: 'white', width: '100%' }}
+          <Grid2 size={6}>
+            <Controller
+              name="student.kana"
+              control={control}
+              render={({ field, fieldState }) => (
+                <TextField
+                  {...field}
+                  error={fieldState.invalid}
+                  helperText={fieldState.error?.message}
+                  type="text"
+                  label="カナ名"
+                  sx={{ backgroundColor: 'white', width: '100%' }}
+                />
+              )}
             />
-          )}
-        />
-      </Grid2>
+          </Grid2>
 
-      <Grid2 size={6}>
-        <Controller
-          name="student.kana"
-          control={control}
-          render={({ field, fieldState }) => (
-            <TextField
-              {...field}
-              error={fieldState.invalid}
-              helperText={fieldState.error?.message}
-              type="text"
-              label="カナ名"
-              sx={{ backgroundColor: 'white', width: '100%' }}
+          <Grid2 size={6}>
+            <Controller
+              name="student.nickName"
+              control={control}
+              render={({ field }) => (
+                <TextField
+                  {...field}
+                  type="text"
+                  label="ニックネーム"
+                  sx={{ backgroundColor: 'white', width: '100%' }}
+                />
+              )}
             />
-          )}
-        />
-      </Grid2>
+          </Grid2>
 
-      <Grid2 size={6}>
-        <Controller
-          name="student.nickName"
-          control={control}
-          render={({ field }) => (
-            <TextField
-              {...field}
-              type="text"
-              label="ニックネーム"
-              sx={{ backgroundColor: 'white', width: '100%' }}
+          <Grid2 size={6}>
+            <Controller
+              name="student.email"
+              control={control}
+              render={({ field, fieldState }) => (
+                <TextField
+                  {...field}
+                  error={fieldState.invalid}
+                  helperText={fieldState.error?.message}
+                  type="email"
+                  label="メールアドレス"
+                  sx={{ backgroundColor: 'white', width: '100%' }}
+                />
+              )}
             />
-          )}
-        />
-      </Grid2>
+          </Grid2>
 
-      <Grid2 size={6}>
-        <Controller
-          name="student.email"
-          control={control}
-          render={({ field, fieldState }) => (
-            <TextField
-              {...field}
-              error={fieldState.invalid}
-              helperText={fieldState.error?.message}
-              type="email"
-              label="メールアドレス"
-              sx={{ backgroundColor: 'white', width: '100%' }}
+          <Grid2 size={4}>
+            <Controller
+              name="student.city"
+              control={control}
+              render={({ field, fieldState }) => (
+                <TextField
+                  {...field}
+                  error={fieldState.invalid}
+                  helperText={fieldState.error?.message}
+                  type="text"
+                  label="居住地域"
+                  sx={{ backgroundColor: 'white', width: '100%' }}
+                />
+              )}
             />
-          )}
-        />
-      </Grid2>
+          </Grid2>
 
-      <Grid2 size={6}>
-        <Controller
-          name="student.city"
-          control={control}
-          render={({ field, fieldState }) => (
-            <TextField
-              {...field}
-              error={fieldState.invalid}
-              helperText={fieldState.error?.message}
-              type="text"
-              label="居住地域"
-              sx={{ backgroundColor: 'white', width: '100%' }}
+          <Grid2 size={4}>
+            <Controller
+              name="student.age"
+              control={control}
+              render={({ field, fieldState }) => (
+                <TextField
+                  {...field}
+                  error={fieldState.invalid}
+                  helperText={fieldState.error?.message}
+                  type="number"
+                  label="年齢"
+                  sx={{ backgroundColor: 'white', width: '100%' }}
+                />
+              )}
             />
-          )}
-        />
-      </Grid2>
+          </Grid2>
 
-      <Grid2 size={6}>
-        <Controller
-          name="student.age"
-          control={control}
-          render={({ field, fieldState }) => (
-            <TextField
-              {...field}
-              error={fieldState.invalid}
-              helperText={fieldState.error?.message}
-              type="number"
-              label="年齢"
-              sx={{ backgroundColor: 'white', width: '100%' }}
+          {studentData.student.gender !== '' && (
+            <Grid2 size={4}>
+              <FormControl sx={{ width: '100%' }}>
+                <InputLabel id="gender">性別</InputLabel>
+                <Controller
+                  name="student.gender"
+                  control={control}
+                  render={({ field }) => (
+                    <Select {...field} labelId="gender" label="gender">
+                      <MenuItem value={'Male'}>Male</MenuItem>
+                      <MenuItem value={'Female'}>Female</MenuItem>
+                      <MenuItem value={'NON_BINARY'}>NON_BINARY</MenuItem>
+                    </Select>
+                  )}
+                />
+              </FormControl>
+            </Grid2>
+          )}
+
+          <Grid2 size={12}>
+            <Controller
+              name="student.remark"
+              control={control}
+              render={({ field, fieldState }) => (
+                <TextField
+                  {...field}
+                  error={fieldState.invalid}
+                  helperText={fieldState.error?.message}
+                  type="text"
+                  label="備考"
+                  sx={{ backgroundColor: 'white', width: '100%' }}
+                />
+              )}
             />
-          )}
-        />
-      </Grid2>
+          </Grid2>
+        </Grid2>
 
-      <Grid2 size={4}>
-        <Controller
-          name="student.gender"
-          control={control}
-          render={({ field, fieldState }) => (
-            <FormControl sx={{ width: '100%' }} error={fieldState.invalid}>
-              <InputLabel id="gender">性別</InputLabel>
+        <Typography variant="h6" gutterBottom sx={{ mt: 3 }}>
+          受講コース
+        </Typography>
 
-              <Select {...field} labelId="gender" label="gender">
-                <MenuItem value={'Male'}>Male</MenuItem>
+        {studentData.studentCourseList.map((studentCourse, index) => (
+          <Grid2 container spacing={2} key={index}>
+            <Grid2 size={4}>
+              <Controller
+                name={`studentCourseList.${index}.courseName`}
+                control={control}
+                render={({ field, fieldState }) => (
+                  <TextField
+                    {...field}
+                    error={fieldState.invalid}
+                    helperText={fieldState.error?.message}
+                    type="text"
+                    label="コース名"
+                    sx={{ backgroundColor: 'white', width: '100%' }}
+                  />
+                )}
+              />
+            </Grid2>
 
-                <MenuItem value={'Female'}>Female</MenuItem>
+            <Grid2 size={3}>
+              <Controller
+                name={`studentCourseList.${index}.startDate`}
+                control={control}
+                render={({ field, fieldState }) => (
+                  <TextField
+                    {...field}
+                    error={fieldState.invalid}
+                    helperText={fieldState.error?.message}
+                    type="string"
+                    label="受講開始日"
+                    sx={{ backgroundColor: 'white', width: '100%' }}
+                  />
+                )}
+              />
+            </Grid2>
 
-                <MenuItem value={'NON_BINARY'}>NON_BINARY</MenuItem>
-              </Select>
+            <Grid2 size={3}>
+              <Controller
+                name={`studentCourseList.${index}.endDate`}
+                control={control}
+                render={({ field, fieldState }) => (
+                  <TextField
+                    {...field}
+                    error={fieldState.invalid}
+                    helperText={fieldState.error?.message}
+                    type="string"
+                    label="受講終了予定日"
+                    sx={{ backgroundColor: 'white', width: '100%' }}
+                  />
+                )}
+              />
+            </Grid2>
 
-              <FormHelperText>{fieldState.error?.message}</FormHelperText>
-            </FormControl>
-          )}
-        />
-      </Grid2>
+            <Grid2 size={2}>
+              <FormControl sx={{ width: '100%' }}>
+                <InputLabel id="status">申込状況</InputLabel>
+                <Controller
+                  name={`studentCourseList.${index}.enrollmentStatus.status`}
+                  control={control}
+                  render={({ field }) => (
+                    <Select {...field} labelId="status" label="status">
+                      <MenuItem value={'仮申込'}>仮申込</MenuItem>
+                      <MenuItem value={'本申込'}>本申込</MenuItem>
+                      <MenuItem value={'受講中'}>受講中</MenuItem>
+                      <MenuItem value={'受講終了'}>受講終了</MenuItem>
+                    </Select>
+                  )}
+                />
+              </FormControl>
+            </Grid2>
+          </Grid2>
+        ))}
 
-      <Grid2 size={6}>
-        <Controller
-          name="student.remark"
-          control={control}
-          render={({ field, fieldState }) => (
-            <TextField
-              {...field}
-              error={fieldState.invalid}
-              helperText={fieldState.error?.message}
-              type="text"
-              label="備考"
-              sx={{ backgroundColor: 'white', width: '100%' }}
-            />
-          )}
-        />
-      </Grid2>
+        <Grid2 container spacing={2} sx={{ mt: 3 }}>
+          <Grid2 size={6}>
+            <Button
+              variant="contained"
+              type="button"
+              size="large"
+              onClick={onSubmit}
+              sx={{ fontWeight: 'bold', color: 'white', width: '100%' }}
+            >
+              更新
+            </Button>
+          </Grid2>
 
-      <Grid2 size={6}>
-        <Controller
-          name="student.isDeleted"
-          control={control}
-          render={({ field }) => (
-            <FormControlLabel control={<Checkbox {...field} />} label="削除" />
-          )}
-        />
-      </Grid2>
-
-      <Grid2 size={4}>
-        <Controller
-          name={`studentCourseList.${0}.courseName`}
-          control={control}
-          render={({ field, fieldState }) => (
-            <TextField
-              {...field}
-              error={fieldState.invalid}
-              helperText={fieldState.error?.message}
-              type="text"
-              label="コース名"
-              sx={{ backgroundColor: 'white', width: '100%' }}
-            />
-          )}
-        />
-      </Grid2>
-
-      <Grid2 size={4}>
-        <Controller
-          name={`studentCourseList.${0}.startDate`}
-          control={control}
-          render={({ field, fieldState }) => (
-            <TextField
-              {...field}
-              error={fieldState.invalid}
-              helperText={fieldState.error?.message}
-              type="string"
-              label="受講開始日"
-              sx={{ backgroundColor: 'white', width: '100%' }}
-            />
-          )}
-        />
-      </Grid2>
-
-      <Grid2 size={4}>
-        <Controller
-          name={`studentCourseList.${0}.endDate`}
-          control={control}
-          render={({ field, fieldState }) => (
-            <TextField
-              {...field}
-              error={fieldState.invalid}
-              helperText={fieldState.error?.message}
-              type="string"
-              label="受講終了予定日"
-              sx={{ backgroundColor: 'white', width: '100%' }}
-            />
-          )}
-        />
-      </Grid2>
-
-      <Grid2 size={4}>
-        <Controller
-          name={`studentCourseList.${0}.enrollmentStatus.status`}
-          control={control}
-          render={({ field, fieldState }) => (
-            <FormControl sx={{ width: '100%' }} error={fieldState.invalid}>
-              <InputLabel id="status">申込状況</InputLabel>
-
-              <Select {...field} labelId="status" label="status">
-                <MenuItem value={'仮申込'}>仮申込</MenuItem>
-
-                <MenuItem value={'本申込'}>本申込</MenuItem>
-
-                <MenuItem value={'受講中'}>受講中</MenuItem>
-
-                <MenuItem value={'受講終了'}>受講終了</MenuItem>
-              </Select>
-
-              <FormHelperText>{fieldState.error?.message}</FormHelperText>
-            </FormControl>
-          )}
-        />
-      </Grid2>
-
-      <Grid2 size={6}>
-        <Button
-          variant="contained"
-          type="button"
-          size="large"
-          sx={{ fontWeight: 'bold', color: 'white', width: '100%' }}
-        >
-          更新
-        </Button>
-      </Grid2>
-
-      <Grid2 size={6}>
-        <Button
-          variant="contained"
-          type="button"
-          color="error"
-          size="large"
-          sx={{ fontWeight: 'bold', color: 'white', width: '100%' }}
-        >
-          キャンセル
-        </Button>
-      </Grid2>
-    </Grid2>
+          <Grid2 size={6}>
+            <Button
+              variant="contained"
+              type="button"
+              color="error"
+              size="large"
+              onClick={onClick}
+              sx={{ fontWeight: 'bold', color: 'white', width: '100%' }}
+            >
+              キャンセル
+            </Button>
+          </Grid2>
+        </Grid2>
+      </form>
+    </Box>
   )
 }
 

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -78,28 +78,6 @@ const StudentPage: NextPage = () => {
       ],
     },
   })
-  const updateForm = useForm<StudentDetailProps>({
-    defaultValues: {
-      student: {
-        id: '',
-        fullName: '',
-        kana: '',
-        nickName: '',
-        email: '',
-        city: '',
-        age: 0,
-        gender: '',
-      },
-      studentCourseList: [
-        {
-          courseName: '',
-          enrollmentStatus: {
-            status: '',
-          },
-        },
-      ],
-    },
-  })
 
   useEffect(() => {
     if (data) {
@@ -268,11 +246,7 @@ const StudentPage: NextPage = () => {
           <Button variant="contained">新規登録</Button>
         </Box>
 
-        <StudentTable
-          data={filteredData}
-          deleteStudent={deleteStudent}
-          updateForm={updateForm}
-        />
+        <StudentTable data={filteredData} deleteStudent={deleteStudent} />
       </Container>
     </Box>
   )

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -8,6 +8,7 @@ import {
 } from '@mui/material'
 import axios, { AxiosError, AxiosResponse } from 'axios'
 import type { NextPage } from 'next'
+import Router from 'next/router'
 import { useEffect, useState } from 'react'
 import { SubmitHandler, useForm } from 'react-hook-form'
 import useSWR from 'swr'
@@ -31,11 +32,13 @@ export type StudentDetailProps = {
   }
   studentCourseList: {
     id: string
+    studentId: string
     courseName: string
     startDate: string
     endDate: string
     enrollmentStatus: {
       id: string
+      studentCourseId: string
       status: string
       createdAt: string
     }
@@ -145,11 +148,11 @@ const StudentPage: NextPage = () => {
     remark,
   ])
 
-  const onSubmit: SubmitHandler<StudentDetailProps> = (data) => {
+  const registerStudent: SubmitHandler<StudentDetailProps> = (formData) => {
     const url = process.env.NEXT_PUBLIC_API_BASE_URL + '/students'
     const headers = { 'Content-Type': 'application/json' }
 
-    axios({ method: 'POST', url: url, data: data, headers: headers })
+    axios({ method: 'POST', url: url, data: formData, headers: headers })
       .then((res: AxiosResponse) => {
         res.status === 200 && mutate()
         handleClickClose()
@@ -179,20 +182,21 @@ const StudentPage: NextPage = () => {
       return
     }
 
-    const data = studentData
-    data.student.isDeleted = true
+    const modifiedData = studentData
+    modifiedData.student.isDeleted = true
 
     const url = process.env.NEXT_PUBLIC_API_BASE_URL + '/students'
     const headers = { 'Content-Type': 'application/json' }
 
-    axios({ method: 'PUT', url: url, data: data, headers: headers })
+    axios({ method: 'PUT', url: url, data: modifiedData, headers: headers })
       .then((res: AxiosResponse) => {
         res.status === 200 && mutate()
         alert(
-          data.student.fullName +
+          modifiedData.student.fullName +
             'さんを削除しました\n\n' +
             'データの復旧を希望の場合は管理者にお問い合わせください',
         )
+        Router.push('/')
       })
       .catch((err: AxiosError<{ error: string }>) => {
         console.log(err)
@@ -214,7 +218,7 @@ const StudentPage: NextPage = () => {
           <DialogTitle>新規受講生登録</DialogTitle>
           <RegisterForm
             control={control}
-            onSubmit={handleSubmit(onSubmit)}
+            onSubmit={handleSubmit(registerStudent)}
             onClick={handleClickClose}
           />
         </Dialog>

--- a/frontend/src/pages/students/[id].tsx
+++ b/frontend/src/pages/students/[id].tsx
@@ -1,6 +1,9 @@
 import {
   Box,
+  Button,
   Container,
+  Dialog,
+  DialogTitle,
   Paper,
   Table,
   TableBody,
@@ -13,10 +16,10 @@ import {
 import axios, { AxiosError, AxiosResponse } from 'axios'
 import { NextPage } from 'next'
 import { useRouter } from 'next/router'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { SubmitHandler, useForm } from 'react-hook-form'
 import useSWR from 'swr'
-import UpdateForm from '@/components/UpdateForm'
+import EditForm from '@/components/EditForm'
 import { StudentDetailProps } from '@/pages/index'
 import { fetcher } from '@/utils'
 
@@ -36,6 +39,7 @@ const StudentDetail: NextPage = () => {
   const router = useRouter()
   const { id } = router.query
   const url = process.env.NEXT_PUBLIC_API_BASE_URL + '/students/'
+  const [isEditFormOpen, setIsEditFormOpen] = useState(false)
 
   const { data, error, mutate } = useSWR(id ? url + id : null, fetcher)
   const { control, handleSubmit, reset } = useForm<StudentDetailProps>({
@@ -56,6 +60,7 @@ const StudentDetail: NextPage = () => {
       .then((res: AxiosResponse) => {
         res.status === 200 && mutate()
         alert(data.student.fullName + 'さんの情報を更新しました')
+        handleEditFormClose()
       })
       .catch((err: AxiosError<{ error: string }>) => {
         console.log(err.message)
@@ -63,8 +68,14 @@ const StudentDetail: NextPage = () => {
       })
   }
 
-  const handleCancelClick = () => {
-    reset(data)
+  const handleEditFormOpen = () => {
+    setIsEditFormOpen(true)
+    reset()
+  }
+
+  const handleEditFormClose = () => {
+    setIsEditFormOpen(false)
+    reset()
   }
 
   if (error) return <div>An error has occurred.</div>
@@ -73,9 +84,14 @@ const StudentDetail: NextPage = () => {
   return (
     <Box sx={{ backgroundColor: '#f9f9f9', minHeight: '100vh', py: 4 }}>
       <Container maxWidth="lg">
-        <Typography variant="h4" gutterBottom>
-          受講生詳細
-        </Typography>
+        <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
+          <Typography variant="h4" gutterBottom>
+            受講生詳細
+          </Typography>
+          <Button onClick={handleEditFormOpen} variant="contained">
+            編集
+          </Button>
+        </Box>
         <Typography variant="h5" gutterBottom>
           基本情報
         </Typography>
@@ -142,12 +158,15 @@ const StudentDetail: NextPage = () => {
           </Table>
         </TableContainer>
 
-        <UpdateForm
-          studentData={data}
-          control={control}
-          onSubmit={handleSubmit(updateStudent)}
-          onClick={handleCancelClick}
-        />
+        <Dialog open={isEditFormOpen} onClose={handleEditFormClose}>
+          <DialogTitle>受講生情報編集</DialogTitle>
+          <EditForm
+            studentData={data}
+            control={control}
+            onSubmit={handleSubmit(updateStudent)}
+            onClick={handleEditFormClose}
+          />
+        </Dialog>
       </Container>
     </Box>
   )

--- a/frontend/src/pages/students/[id].tsx
+++ b/frontend/src/pages/students/[id].tsx
@@ -78,6 +78,10 @@ const StudentDetail: NextPage = () => {
     reset()
   }
 
+  const handleReset = () => {
+    reset()
+  }
+
   if (error) return <div>An error has occurred.</div>
   if (!data) return <div>Loading...</div>
 
@@ -164,7 +168,8 @@ const StudentDetail: NextPage = () => {
             studentData={data}
             control={control}
             onSubmit={handleSubmit(updateStudent)}
-            onClick={handleEditFormClose}
+            onCancel={handleEditFormClose}
+            onReset={handleReset}
           />
         </Dialog>
       </Container>


### PR DESCRIPTION
## 変更の概要
- 更新用画面を実装しました
  - 受講生詳細画面から編集ボタンを押下するとフォームが開きます
  - 更新ボタンを押下で実行、キャンセルボタンを押すと元の画面に戻ります

## なぜこの変更をするのか
- 更新処理を画面上から行えるようにするため

## 変更内容
![無題の動画-‐-Clipchampで作成-_3_](https://github.com/user-attachments/assets/8dfe2ffb-b2cf-4699-ac63-bc7e44873da4)

## 使い方
- 受講生詳細画面の左上にある編集ボタンを押下
- フォームが開く
  - 初期値として現在の登録内容が記載されています
  - 編集後左下の更新ボタンを押下すると更新します
  - 中央のリセットボタンを押下するとフォームの記述内容を初期値に戻します
  - 右側のキャンセルボタンを押下するとダイアログを閉じ、フォームの記述内容を初期化します

## 備考
受講生詳細画面には申込状況更新機能も実装する予定です
