### PR TITLE
feat: 申込状況更新機能画面を実装しました

### DIFF
--- a/frontend/src/components/EditForm.tsx
+++ b/frontend/src/components/EditForm.tsx
@@ -13,6 +13,7 @@ import {
 import { Control, Controller } from 'react-hook-form'
 
 import { StudentDetailProps } from '@/pages'
+import { validationRules } from '@/utils'
 
 type updateFormProps = {
   studentData: StudentDetailProps
@@ -41,6 +42,7 @@ const EditForm: React.FC<updateFormProps> = ({
             <Controller
               name="student.fullName"
               control={control}
+              rules={validationRules.student.fullName}
               render={({ field, fieldState }) => (
                 <TextField
                   {...field}
@@ -58,6 +60,7 @@ const EditForm: React.FC<updateFormProps> = ({
             <Controller
               name="student.kana"
               control={control}
+              rules={validationRules.student.kana}
               render={({ field, fieldState }) => (
                 <TextField
                   {...field}
@@ -90,6 +93,7 @@ const EditForm: React.FC<updateFormProps> = ({
             <Controller
               name="student.email"
               control={control}
+              rules={validationRules.student.email}
               render={({ field, fieldState }) => (
                 <TextField
                   {...field}
@@ -107,6 +111,7 @@ const EditForm: React.FC<updateFormProps> = ({
             <Controller
               name="student.city"
               control={control}
+              rules={validationRules.student.city}
               render={({ field, fieldState }) => (
                 <TextField
                   {...field}
@@ -124,6 +129,7 @@ const EditForm: React.FC<updateFormProps> = ({
             <Controller
               name="student.age"
               control={control}
+              rules={validationRules.student.age}
               render={({ field, fieldState }) => (
                 <TextField
                   {...field}
@@ -160,11 +166,9 @@ const EditForm: React.FC<updateFormProps> = ({
             <Controller
               name="student.remark"
               control={control}
-              render={({ field, fieldState }) => (
+              render={({ field }) => (
                 <TextField
                   {...field}
-                  error={fieldState.invalid}
-                  helperText={fieldState.error?.message}
                   type="text"
                   label="備考"
                   sx={{ backgroundColor: 'white', width: '100%' }}
@@ -184,6 +188,7 @@ const EditForm: React.FC<updateFormProps> = ({
               <Controller
                 name={`studentCourseList.${index}.courseName`}
                 control={control}
+                rules={validationRules.studentCourseList.courseName}
                 render={({ field, fieldState }) => (
                   <TextField
                     {...field}
@@ -201,6 +206,7 @@ const EditForm: React.FC<updateFormProps> = ({
               <Controller
                 name={`studentCourseList.${index}.startDate`}
                 control={control}
+                rules={validationRules.studentCourseList.startData}
                 render={({ field, fieldState }) => (
                   <TextField
                     {...field}
@@ -218,6 +224,7 @@ const EditForm: React.FC<updateFormProps> = ({
               <Controller
                 name={`studentCourseList.${index}.endDate`}
                 control={control}
+                rules={validationRules.studentCourseList.endData}
                 render={({ field, fieldState }) => (
                   <TextField
                     {...field}

--- a/frontend/src/components/EditForm.tsx
+++ b/frontend/src/components/EditForm.tsx
@@ -183,61 +183,66 @@ const EditForm: React.FC<updateFormProps> = ({
         </Typography>
 
         {studentData.studentCourseList.map((studentCourse, index) => (
-          <Grid2 container spacing={2} key={index}>
-            <Grid2 size={12}>
-              <Controller
-                name={`studentCourseList.${index}.courseName`}
-                control={control}
-                rules={validationRules.studentCourseList.courseName}
-                render={({ field, fieldState }) => (
-                  <TextField
-                    {...field}
-                    error={fieldState.invalid}
-                    helperText={fieldState.error?.message}
-                    type="text"
-                    label="コース名"
-                    sx={{ backgroundColor: 'white', width: '100%' }}
-                  />
-                )}
-              />
-            </Grid2>
+          <Box sx={{ mt: 1 }} key={index}>
+            <Typography gutterBottom sx={{ mt: 1, mb: 1 }}>
+              受講コース{index + 1}
+            </Typography>
+            <Grid2 container spacing={2}>
+              <Grid2 size={12}>
+                <Controller
+                  name={`studentCourseList.${index}.courseName`}
+                  control={control}
+                  rules={validationRules.studentCourseList.courseName}
+                  render={({ field, fieldState }) => (
+                    <TextField
+                      {...field}
+                      error={fieldState.invalid}
+                      helperText={fieldState.error?.message}
+                      type="text"
+                      label="コース名"
+                      sx={{ backgroundColor: 'white', width: '100%' }}
+                    />
+                  )}
+                />
+              </Grid2>
 
-            <Grid2 size={6}>
-              <Controller
-                name={`studentCourseList.${index}.startDate`}
-                control={control}
-                rules={validationRules.studentCourseList.startData}
-                render={({ field, fieldState }) => (
-                  <TextField
-                    {...field}
-                    error={fieldState.invalid}
-                    helperText={fieldState.error?.message}
-                    type="string"
-                    label="受講開始日"
-                    sx={{ backgroundColor: 'white', width: '100%' }}
-                  />
-                )}
-              />
-            </Grid2>
+              <Grid2 size={6}>
+                <Controller
+                  name={`studentCourseList.${index}.startDate`}
+                  control={control}
+                  rules={validationRules.studentCourseList.startData}
+                  render={({ field, fieldState }) => (
+                    <TextField
+                      {...field}
+                      error={fieldState.invalid}
+                      helperText={fieldState.error?.message}
+                      type="string"
+                      label="受講開始日"
+                      sx={{ backgroundColor: 'white', width: '100%' }}
+                    />
+                  )}
+                />
+              </Grid2>
 
-            <Grid2 size={6}>
-              <Controller
-                name={`studentCourseList.${index}.endDate`}
-                control={control}
-                rules={validationRules.studentCourseList.endData}
-                render={({ field, fieldState }) => (
-                  <TextField
-                    {...field}
-                    error={fieldState.invalid}
-                    helperText={fieldState.error?.message}
-                    type="string"
-                    label="受講終了予定日"
-                    sx={{ backgroundColor: 'white', width: '100%' }}
-                  />
-                )}
-              />
+              <Grid2 size={6}>
+                <Controller
+                  name={`studentCourseList.${index}.endDate`}
+                  control={control}
+                  rules={validationRules.studentCourseList.endData}
+                  render={({ field, fieldState }) => (
+                    <TextField
+                      {...field}
+                      error={fieldState.invalid}
+                      helperText={fieldState.error?.message}
+                      type="string"
+                      label="受講終了予定日"
+                      sx={{ backgroundColor: 'white', width: '100%' }}
+                    />
+                  )}
+                />
+              </Grid2>
             </Grid2>
-          </Grid2>
+          </Box>
         ))}
 
         <Grid2 container spacing={2} sx={{ mt: 3 }}>

--- a/frontend/src/components/EnrollmentStatusForm.tsx
+++ b/frontend/src/components/EnrollmentStatusForm.tsx
@@ -1,0 +1,91 @@
+import {
+  Box,
+  Grid2,
+  TextField,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  Button,
+} from '@mui/material'
+import { Controller, UseFormReturn } from 'react-hook-form'
+
+import { EnrollmentStatusFormData } from '@/pages/students/[id]'
+
+type EnrollmentStatusFormProps = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  formHandler: UseFormReturn<EnrollmentStatusFormData, any, undefined>
+  onSubmit: () => void
+  onCancel: () => void
+}
+
+const EnrollmentStatusForm: React.FC<EnrollmentStatusFormProps> = ({
+  formHandler,
+  onSubmit,
+  onCancel,
+}) => {
+  return (
+    <Box sx={{ m: 2 }}>
+      <Grid2 container component="form" spacing={2}>
+        <Grid2 size={12}>
+          <Controller
+            name="studentCourseId"
+            control={formHandler.control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                error={fieldState.invalid}
+                helperText={fieldState.error?.message}
+                type="text"
+                label="コースID"
+                sx={{ backgroundColor: 'white', width: '100%' }}
+              />
+            )}
+          />
+        </Grid2>
+        <Grid2 size={12}>
+          <FormControl sx={{ width: '100%' }}>
+            <InputLabel id="status">申込状況</InputLabel>
+            <Controller
+              name="status"
+              control={formHandler.control}
+              render={({ field }) => (
+                <Select {...field} labelId="status" label="status">
+                  <MenuItem value={'仮申込'}>仮申込</MenuItem>
+                  <MenuItem value={'本申込'}>本申込</MenuItem>
+                  <MenuItem value={'受講中'}>受講中</MenuItem>
+                  <MenuItem value={'受講終了…'}>受講終了</MenuItem>
+                </Select>
+              )}
+            />
+          </FormControl>
+        </Grid2>
+        <Grid2 size={6}>
+          <Button
+            variant="contained"
+            type="button"
+            size="large"
+            onClick={onSubmit}
+            sx={{ fontWeight: 'bold', color: 'white', width: '100%' }}
+          >
+            更新
+          </Button>
+        </Grid2>
+        <Grid2 size={6}>
+          <Button
+            variant="contained"
+            type="button"
+            color="error"
+            size="large"
+            onClick={onCancel}
+            sx={{ fontWeight: 'bold', color: 'white', width: '100%' }}
+          >
+            キャンセル
+          </Button>
+        </Grid2>
+      </Grid2>
+    </Box>
+  )
+}
+
+export default EnrollmentStatusForm

--- a/frontend/src/components/EnrollmentStatusForm.tsx
+++ b/frontend/src/components/EnrollmentStatusForm.tsx
@@ -34,6 +34,7 @@ const EnrollmentStatusForm: React.FC<EnrollmentStatusFormProps> = ({
             render={({ field, fieldState }) => (
               <TextField
                 {...field}
+                disabled={true}
                 error={fieldState.invalid}
                 helperText={fieldState.error?.message}
                 type="text"
@@ -54,7 +55,7 @@ const EnrollmentStatusForm: React.FC<EnrollmentStatusFormProps> = ({
                   <MenuItem value={'仮申込'}>仮申込</MenuItem>
                   <MenuItem value={'本申込'}>本申込</MenuItem>
                   <MenuItem value={'受講中'}>受講中</MenuItem>
-                  <MenuItem value={'受講終了…'}>受講終了</MenuItem>
+                  <MenuItem value={'受講終了'}>受講終了</MenuItem>
                 </Select>
               )}
             />

--- a/frontend/src/components/RegisterForm.tsx
+++ b/frontend/src/components/RegisterForm.tsx
@@ -12,6 +12,7 @@ import {
 
 import { Control, Controller } from 'react-hook-form'
 import { StudentDetailProps } from '@/pages'
+import { validationRules } from '@/utils'
 
 type RegisterFormProps = {
   control: Control<StudentDetailProps>
@@ -24,64 +25,6 @@ const RegisterForm: React.FC<RegisterFormProps> = ({
   onSubmit,
   onClick,
 }) => {
-  const validationRules = {
-    student: {
-      fullName: {
-        required: '氏名は必須です',
-      },
-      kana: {
-        pattern: {
-          // eslint-disable-next-line no-irregular-whitespace
-          value: /^$|^[ァ-ヶー\s　]+$/,
-          message: 'カナ名はカタカナとスペースのみを入力してください',
-        },
-      },
-      email: {
-        required: 'メールアドレスは必須です',
-        pattern: {
-          value: /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/,
-          message: '正しい形式のメールアドレスを入力してください。',
-        },
-      },
-      city: {
-        required: '居住地域は必須です',
-      },
-      age: {
-        min: {
-          value: 0,
-          message: '年齢は0歳以上である必要があります',
-        },
-        max: {
-          value: 150,
-          message: '年齢は150歳以下である必要があります',
-        },
-      },
-      gender: {
-        validate: (value: string) => {
-          return (
-            ['Male', 'Female', 'NON_BINARY', ''].includes(value) ||
-            '性別はMale, Female, NON_BINARY のいずれかを指定してください'
-          )
-        },
-      },
-    },
-    studentCourseList: {
-      courseName: {
-        required: 'コース名は必須です',
-      },
-      enrollmentStatus: {
-        status: {
-          required: '申込状況は必須です',
-          validate: (value: string) => {
-            return (
-              ['仮申込', '本申込', '受講中', '受講終了'].includes(value) ||
-              '申込状況は仮申込, 本申込, 受講中, 受講終了 のいずれかを指定してください'
-            )
-          },
-        },
-      },
-    },
-  }
   return (
     <Box sx={{ m: 2 }}>
       <Grid2 container component="form" spacing={2}>

--- a/frontend/src/components/StudentCourseTable.tsx
+++ b/frontend/src/components/StudentCourseTable.tsx
@@ -1,0 +1,57 @@
+import {
+  TableContainer,
+  Paper,
+  Table,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableBody,
+} from '@mui/material'
+import { StudentDetailProps } from '@/pages'
+
+type StudentCourseTableProps = {
+  data: StudentDetailProps
+}
+
+type StudentCourseProps = {
+  id: string
+  courseName: string
+  startDate: string
+  endDate: string
+  enrollmentStatus: {
+    id: string
+    status: string
+    createdAt: string
+  }
+}
+
+const StudentCourseTable: React.FC<StudentCourseTableProps> = ({ data }) => {
+  return (
+    <TableContainer component={Paper}>
+      <Table sx={{ minWidth: 650 }}>
+        <TableHead>
+          <TableRow>
+            <TableCell>受講コース名</TableCell>
+            <TableCell>受講開始日</TableCell>
+            <TableCell>受講修了予定日</TableCell>
+            <TableCell>申込状況</TableCell>
+            <TableCell>申込状況更新日時</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {data.studentCourseList.map((studentCourse: StudentCourseProps) => (
+            <TableRow key={studentCourse.id}>
+              <TableCell>{studentCourse.courseName}</TableCell>
+              <TableCell>{studentCourse.startDate}</TableCell>
+              <TableCell>{studentCourse.endDate}</TableCell>
+              <TableCell>{studentCourse.enrollmentStatus.status}</TableCell>
+              <TableCell>{studentCourse.enrollmentStatus.createdAt}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  )
+}
+
+export default StudentCourseTable

--- a/frontend/src/components/StudentCourseTable.tsx
+++ b/frontend/src/components/StudentCourseTable.tsx
@@ -6,11 +6,17 @@ import {
   TableRow,
   TableCell,
   TableBody,
+  Button,
 } from '@mui/material'
+import { UseFormReturn } from 'react-hook-form'
 import { StudentDetailProps } from '@/pages'
+import { EnrollmentStatusFormProps } from '@/pages/students/[id]'
 
 type StudentCourseTableProps = {
   data: StudentDetailProps
+  onClick: (studentCourseId: string, enrollmentStatus: string) => void
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  formHandler: UseFormReturn<EnrollmentStatusFormProps, any, undefined>
 }
 
 type StudentCourseProps = {
@@ -25,7 +31,10 @@ type StudentCourseProps = {
   }
 }
 
-const StudentCourseTable: React.FC<StudentCourseTableProps> = ({ data }) => {
+const StudentCourseTable: React.FC<StudentCourseTableProps> = ({
+  data,
+  onClick,
+}) => {
   return (
     <TableContainer component={Paper}>
       <Table sx={{ minWidth: 650 }}>
@@ -36,6 +45,7 @@ const StudentCourseTable: React.FC<StudentCourseTableProps> = ({ data }) => {
             <TableCell>受講修了予定日</TableCell>
             <TableCell>申込状況</TableCell>
             <TableCell>申込状況更新日時</TableCell>
+            <TableCell>申込状況更新</TableCell>
           </TableRow>
         </TableHead>
         <TableBody>
@@ -46,6 +56,19 @@ const StudentCourseTable: React.FC<StudentCourseTableProps> = ({ data }) => {
               <TableCell>{studentCourse.endDate}</TableCell>
               <TableCell>{studentCourse.enrollmentStatus.status}</TableCell>
               <TableCell>{studentCourse.enrollmentStatus.createdAt}</TableCell>
+              <TableCell>
+                <Button
+                  variant="outlined"
+                  onClick={() =>
+                    onClick(
+                      studentCourse.id,
+                      studentCourse.enrollmentStatus.status,
+                    )
+                  }
+                >
+                  申込状況更新
+                </Button>
+              </TableCell>
             </TableRow>
           ))}
         </TableBody>

--- a/frontend/src/components/StudentCourseTable.tsx
+++ b/frontend/src/components/StudentCourseTable.tsx
@@ -8,15 +8,11 @@ import {
   TableBody,
   Button,
 } from '@mui/material'
-import { UseFormReturn } from 'react-hook-form'
 import { StudentDetailProps } from '@/pages'
-import { EnrollmentStatusFormProps } from '@/pages/students/[id]'
 
 type StudentCourseTableProps = {
   data: StudentDetailProps
   onClick: (studentCourseId: string, enrollmentStatus: string) => void
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  formHandler: UseFormReturn<EnrollmentStatusFormProps, any, undefined>
 }
 
 type StudentCourseProps = {

--- a/frontend/src/components/StudentInfoTable.tsx
+++ b/frontend/src/components/StudentInfoTable.tsx
@@ -1,0 +1,50 @@
+import {
+  TableContainer,
+  Paper,
+  Table,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableBody,
+} from '@mui/material'
+import { StudentDetailProps } from '@/pages'
+
+type StudentInfoTableProps = {
+  data: StudentDetailProps
+}
+
+const StudentInfoTable: React.FC<StudentInfoTableProps> = ({ data }) => {
+  return (
+    <TableContainer component={Paper} sx={{ mb: 2 }}>
+      <Table sx={{ minWidth: 650 }}>
+        <TableHead>
+          <TableRow>
+            <TableCell>氏名</TableCell>
+            <TableCell>カナ名</TableCell>
+            <TableCell>ニックネーム</TableCell>
+            <TableCell>メールアドレス</TableCell>
+            <TableCell>居住地域</TableCell>
+            <TableCell>年齢</TableCell>
+            <TableCell>性別</TableCell>
+            <TableCell>備考</TableCell>
+          </TableRow>
+        </TableHead>
+
+        <TableBody>
+          <TableRow key={data.student.id}>
+            <TableCell>{data.student.fullName}</TableCell>
+            <TableCell>{data.student.kana}</TableCell>
+            <TableCell>{data.student.nickName}</TableCell>
+            <TableCell>{data.student.email}</TableCell>
+            <TableCell>{data.student.city}</TableCell>
+            <TableCell>{data.student.age}</TableCell>
+            <TableCell>{data.student.gender}</TableCell>
+            <TableCell>{data.student.remark}</TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>
+    </TableContainer>
+  )
+}
+
+export default StudentInfoTable

--- a/frontend/src/pages/students/[id].tsx
+++ b/frontend/src/pages/students/[id].tsx
@@ -58,7 +58,7 @@ const StudentDetail: NextPage = () => {
         handleEditFormClose()
       })
       .catch((err: AxiosError<{ error: string }>) => {
-        console.log(err)
+        console.log(err.message)
         alert(err.message)
       })
   }
@@ -89,9 +89,9 @@ const StudentDetail: NextPage = () => {
         alert('申込状況を更新しました')
         handleStatusFormClose()
       })
-      .catch((err: AxiosError<{ error: string }>) => {
-        console.log(err.message)
-        alert(err.message)
+      .catch((err: AxiosError<{ message: string }>) => {
+        console.log(err)
+        alert(err.response?.data.message)
       })
   }
 

--- a/frontend/src/pages/students/[id].tsx
+++ b/frontend/src/pages/students/[id].tsx
@@ -4,27 +4,22 @@ import {
   Container,
   Dialog,
   DialogTitle,
-  FormControl,
-  Grid2,
-  InputLabel,
-  MenuItem,
-  Select,
-  TextField,
   Typography,
 } from '@mui/material'
 import axios, { AxiosError, AxiosResponse } from 'axios'
 import { NextPage } from 'next'
 import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
-import { Controller, SubmitHandler, useForm } from 'react-hook-form'
+import { SubmitHandler, useForm } from 'react-hook-form'
 import useSWR from 'swr'
 import EditForm from '@/components/EditForm'
+import EnrollmentStatusForm from '@/components/EnrollmentStatusForm'
 import StudentCourseTable from '@/components/StudentCourseTable'
 import StudentInfoTable from '@/components/StudentInfoTable'
 import { StudentDetailProps } from '@/pages/index'
 import { fetcher } from '@/utils'
 
-export type EnrollmentStatusFormProps = {
+export type EnrollmentStatusFormData = {
   studentCourseId: string
   status: string
 }
@@ -39,7 +34,7 @@ const StudentDetail: NextPage = () => {
   const editFormHandler = useForm<StudentDetailProps>({
     defaultValues: data,
   })
-  const enrollmentStatusFormHandler = useForm<EnrollmentStatusFormProps>()
+  const enrollmentStatusFormHandler = useForm<EnrollmentStatusFormData>()
 
   useEffect(() => {
     if (data) {
@@ -75,7 +70,7 @@ const StudentDetail: NextPage = () => {
     editFormHandler.reset()
   }
 
-  const updateEnrollmentStatus: SubmitHandler<EnrollmentStatusFormProps> = (
+  const updateEnrollmentStatus: SubmitHandler<EnrollmentStatusFormData> = (
     formData,
   ) => {
     const url =
@@ -130,11 +125,7 @@ const StudentDetail: NextPage = () => {
           受講コース
         </Typography>
 
-        <StudentCourseTable
-          data={data}
-          onClick={handleStatusFormOpen}
-          formHandler={enrollmentStatusFormHandler}
-        />
+        <StudentCourseTable data={data} onClick={handleStatusFormOpen} />
 
         <Dialog open={isEditFormOpen} onClose={handleEditFormClose}>
           <DialogTitle>受講生情報編集</DialogTitle>
@@ -149,7 +140,14 @@ const StudentDetail: NextPage = () => {
 
         <Dialog open={isStatusFormOpen} onClose={handleStatusFormClose}>
           <DialogTitle>申込状況更新</DialogTitle>
-          <Box sx={{ m: 2 }}>
+          <EnrollmentStatusForm
+            formHandler={enrollmentStatusFormHandler}
+            onSubmit={enrollmentStatusFormHandler.handleSubmit(
+              updateEnrollmentStatus,
+            )}
+            onCancel={handleStatusFormClose}
+          />
+          {/* <Box sx={{ m: 2 }}>
             <Grid2 container component="form" spacing={2}>
               <Grid2 size={12}>
                 <Controller
@@ -210,7 +208,7 @@ const StudentDetail: NextPage = () => {
                 </Button>
               </Grid2>
             </Grid2>
-          </Box>
+          </Box> */}
         </Dialog>
       </Container>
     </Box>

--- a/frontend/src/pages/students/[id].tsx
+++ b/frontend/src/pages/students/[id].tsx
@@ -4,13 +4,19 @@ import {
   Container,
   Dialog,
   DialogTitle,
+  FormControl,
+  Grid2,
+  InputLabel,
+  MenuItem,
+  Select,
+  TextField,
   Typography,
 } from '@mui/material'
 import axios, { AxiosError, AxiosResponse } from 'axios'
 import { NextPage } from 'next'
 import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
-import { SubmitHandler, useForm } from 'react-hook-form'
+import { Controller, SubmitHandler, useForm } from 'react-hook-form'
 import useSWR from 'swr'
 import EditForm from '@/components/EditForm'
 import StudentCourseTable from '@/components/StudentCourseTable'
@@ -18,22 +24,28 @@ import StudentInfoTable from '@/components/StudentInfoTable'
 import { StudentDetailProps } from '@/pages/index'
 import { fetcher } from '@/utils'
 
+export type EnrollmentStatusFormProps = {
+  studentCourseId: string
+  status: string
+}
+
 const StudentDetail: NextPage = () => {
   const router = useRouter()
   const { id } = router.query
   const url = process.env.NEXT_PUBLIC_API_BASE_URL + '/students/'
   const [isEditFormOpen, setIsEditFormOpen] = useState(false)
-
+  const [isStatusFormOpen, setIsStatusFormOpen] = useState(false)
   const { data, error, mutate } = useSWR(id ? url + id : null, fetcher)
-  const { control, handleSubmit, reset } = useForm<StudentDetailProps>({
+  const editFormHandler = useForm<StudentDetailProps>({
     defaultValues: data,
   })
+  const enrollmentStatusFormHandler = useForm<EnrollmentStatusFormProps>()
 
   useEffect(() => {
     if (data) {
-      reset(data)
+      editFormHandler.reset(data)
     }
-  }, [data, reset])
+  }, [data, editFormHandler])
 
   const updateStudent: SubmitHandler<StudentDetailProps> = (formData) => {
     const url = process.env.NEXT_PUBLIC_API_BASE_URL + '/students'
@@ -46,23 +58,53 @@ const StudentDetail: NextPage = () => {
         handleEditFormClose()
       })
       .catch((err: AxiosError<{ error: string }>) => {
-        console.log(err.message)
+        console.log(err)
         alert(err.message)
       })
   }
 
   const handleEditFormOpen = () => {
     setIsEditFormOpen(true)
-    reset()
+    editFormHandler.reset()
   }
-
   const handleEditFormClose = () => {
     setIsEditFormOpen(false)
-    reset()
+    editFormHandler.reset()
+  }
+  const handleEditFormReset = () => {
+    editFormHandler.reset()
   }
 
-  const handleReset = () => {
-    reset()
+  const updateEnrollmentStatus: SubmitHandler<EnrollmentStatusFormProps> = (
+    formData,
+  ) => {
+    const url =
+      process.env.NEXT_PUBLIC_API_BASE_URL +
+      '/students/courses/enrollment-status'
+    const headers = { 'Content-Type': 'application/json' }
+
+    axios({ method: 'post', url: url, data: formData, headers: headers })
+      .then((res: AxiosResponse) => {
+        res.status === 200 && mutate()
+        alert('申込状況を更新しました')
+        handleStatusFormClose()
+      })
+      .catch((err: AxiosError<{ error: string }>) => {
+        console.log(err.message)
+        alert(err.message)
+      })
+  }
+
+  const handleStatusFormOpen = (
+    studentCourseId: string,
+    enrollmentStatus: string,
+  ) => {
+    setIsStatusFormOpen(true)
+    enrollmentStatusFormHandler.setValue('studentCourseId', studentCourseId)
+    enrollmentStatusFormHandler.setValue('status', enrollmentStatus)
+  }
+  const handleStatusFormClose = () => {
+    setIsStatusFormOpen(false)
   }
 
   if (error) return <div>An error has occurred.</div>
@@ -88,17 +130,87 @@ const StudentDetail: NextPage = () => {
           受講コース
         </Typography>
 
-        <StudentCourseTable data={data} />
+        <StudentCourseTable
+          data={data}
+          onClick={handleStatusFormOpen}
+          formHandler={enrollmentStatusFormHandler}
+        />
 
         <Dialog open={isEditFormOpen} onClose={handleEditFormClose}>
           <DialogTitle>受講生情報編集</DialogTitle>
           <EditForm
             studentData={data}
-            control={control}
-            onSubmit={handleSubmit(updateStudent)}
+            control={editFormHandler.control}
+            onSubmit={editFormHandler.handleSubmit(updateStudent)}
             onCancel={handleEditFormClose}
-            onReset={handleReset}
+            onReset={handleEditFormReset}
           />
+        </Dialog>
+
+        <Dialog open={isStatusFormOpen} onClose={handleStatusFormClose}>
+          <DialogTitle>申込状況更新</DialogTitle>
+          <Box sx={{ m: 2 }}>
+            <Grid2 container component="form" spacing={2}>
+              <Grid2 size={12}>
+                <Controller
+                  name="studentCourseId"
+                  control={enrollmentStatusFormHandler.control}
+                  render={({ field, fieldState }) => (
+                    <TextField
+                      {...field}
+                      error={fieldState.invalid}
+                      helperText={fieldState.error?.message}
+                      type="text"
+                      label="コースID"
+                      sx={{ backgroundColor: 'white', width: '100%' }}
+                    />
+                  )}
+                />
+              </Grid2>
+              <Grid2 size={12}>
+                <FormControl sx={{ width: '100%' }}>
+                  <InputLabel id="status">申込状況</InputLabel>
+                  <Controller
+                    name="status"
+                    control={enrollmentStatusFormHandler.control}
+                    render={({ field }) => (
+                      <Select {...field} labelId="status" label="status">
+                        <MenuItem value={'仮申込'}>仮申込</MenuItem>
+                        <MenuItem value={'本申込'}>本申込</MenuItem>
+                        <MenuItem value={'受講中'}>受講中</MenuItem>
+                        <MenuItem value={'受講終了…'}>受講終了</MenuItem>
+                      </Select>
+                    )}
+                  />
+                </FormControl>
+              </Grid2>
+              <Grid2 size={6}>
+                <Button
+                  variant="contained"
+                  type="button"
+                  size="large"
+                  onClick={enrollmentStatusFormHandler.handleSubmit(
+                    updateEnrollmentStatus,
+                  )}
+                  sx={{ fontWeight: 'bold', color: 'white', width: '100%' }}
+                >
+                  更新
+                </Button>
+              </Grid2>
+              <Grid2 size={6}>
+                <Button
+                  variant="contained"
+                  type="button"
+                  color="error"
+                  size="large"
+                  onClick={handleStatusFormClose}
+                  sx={{ fontWeight: 'bold', color: 'white', width: '100%' }}
+                >
+                  キャンセル
+                </Button>
+              </Grid2>
+            </Grid2>
+          </Box>
         </Dialog>
       </Container>
     </Box>

--- a/frontend/src/pages/students/[id].tsx
+++ b/frontend/src/pages/students/[id].tsx
@@ -4,13 +4,6 @@ import {
   Container,
   Dialog,
   DialogTitle,
-  Paper,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
   Typography,
 } from '@mui/material'
 import axios, { AxiosError, AxiosResponse } from 'axios'
@@ -20,20 +13,10 @@ import { useEffect, useState } from 'react'
 import { SubmitHandler, useForm } from 'react-hook-form'
 import useSWR from 'swr'
 import EditForm from '@/components/EditForm'
+import StudentCourseTable from '@/components/StudentCourseTable'
+import StudentInfoTable from '@/components/StudentInfoTable'
 import { StudentDetailProps } from '@/pages/index'
 import { fetcher } from '@/utils'
-
-type StudentCourseProps = {
-  id: string
-  courseName: string
-  startDate: string
-  endDate: string
-  enrollmentStatus: {
-    id: string
-    status: string
-    createdAt: string
-  }
-}
 
 const StudentDetail: NextPage = () => {
   const router = useRouter()
@@ -59,7 +42,7 @@ const StudentDetail: NextPage = () => {
     axios({ method: 'PUT', url: url, data: formData, headers: headers })
       .then((res: AxiosResponse) => {
         res.status === 200 && mutate()
-        alert(data.student.fullName + 'さんの情報を更新しました')
+        alert(formData.student.fullName + 'さんの情報を更新しました')
         handleEditFormClose()
       })
       .catch((err: AxiosError<{ error: string }>) => {
@@ -99,68 +82,13 @@ const StudentDetail: NextPage = () => {
         <Typography variant="h5" gutterBottom>
           基本情報
         </Typography>
-        <TableContainer component={Paper} sx={{ mb: 2 }}>
-          <Table sx={{ minWidth: 650 }}>
-            <TableHead>
-              <TableRow>
-                <TableCell>氏名</TableCell>
-                <TableCell>カナ名</TableCell>
-                <TableCell>ニックネーム</TableCell>
-                <TableCell>メールアドレス</TableCell>
-                <TableCell>居住地域</TableCell>
-                <TableCell>年齢</TableCell>
-                <TableCell>性別</TableCell>
-                <TableCell>備考</TableCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              <TableRow key={data.student.id}>
-                <TableCell>{data.student.fullName}</TableCell>
-                <TableCell>{data.student.kana}</TableCell>
-                <TableCell>{data.student.nickName}</TableCell>
-                <TableCell>{data.student.email}</TableCell>
-                <TableCell>{data.student.city}</TableCell>
-                <TableCell>{data.student.age}</TableCell>
-                <TableCell>{data.student.gender}</TableCell>
-                <TableCell>{data.student.remark}</TableCell>
-              </TableRow>
-            </TableBody>
-          </Table>
-        </TableContainer>
+        <StudentInfoTable data={data} />
 
         <Typography variant="h5" gutterBottom>
           受講コース
         </Typography>
-        <TableContainer component={Paper}>
-          <Table sx={{ minWidth: 650 }}>
-            <TableHead>
-              <TableRow>
-                <TableCell>受講コース名</TableCell>
-                <TableCell>受講開始日</TableCell>
-                <TableCell>受講修了予定日</TableCell>
-                <TableCell>申込状況</TableCell>
-                <TableCell>申込状況更新日時</TableCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {data.studentCourseList.map(
-                (studentCourse: StudentCourseProps) => (
-                  <TableRow key={studentCourse.id}>
-                    <TableCell>{studentCourse.courseName}</TableCell>
-                    <TableCell>{studentCourse.startDate}</TableCell>
-                    <TableCell>{studentCourse.endDate}</TableCell>
-                    <TableCell>
-                      {studentCourse.enrollmentStatus.status}
-                    </TableCell>
-                    <TableCell>
-                      {studentCourse.enrollmentStatus.createdAt}
-                    </TableCell>
-                  </TableRow>
-                ),
-              )}
-            </TableBody>
-          </Table>
-        </TableContainer>
+
+        <StudentCourseTable data={data} />
 
         <Dialog open={isEditFormOpen} onClose={handleEditFormClose}>
           <DialogTitle>受講生情報編集</DialogTitle>

--- a/frontend/src/pages/students/[id].tsx
+++ b/frontend/src/pages/students/[id].tsx
@@ -73,6 +73,13 @@ const StudentDetail: NextPage = () => {
   const updateEnrollmentStatus: SubmitHandler<EnrollmentStatusFormData> = (
     formData,
   ) => {
+    const confirmDelete = window.confirm(
+      'ステータスを元に戻すことはできません。誤りはありませんか？',
+    )
+
+    if (!confirmDelete) {
+      return
+    }
     const url =
       process.env.NEXT_PUBLIC_API_BASE_URL +
       '/students/courses/enrollment-status'
@@ -147,68 +154,6 @@ const StudentDetail: NextPage = () => {
             )}
             onCancel={handleStatusFormClose}
           />
-          {/* <Box sx={{ m: 2 }}>
-            <Grid2 container component="form" spacing={2}>
-              <Grid2 size={12}>
-                <Controller
-                  name="studentCourseId"
-                  control={enrollmentStatusFormHandler.control}
-                  render={({ field, fieldState }) => (
-                    <TextField
-                      {...field}
-                      error={fieldState.invalid}
-                      helperText={fieldState.error?.message}
-                      type="text"
-                      label="コースID"
-                      sx={{ backgroundColor: 'white', width: '100%' }}
-                    />
-                  )}
-                />
-              </Grid2>
-              <Grid2 size={12}>
-                <FormControl sx={{ width: '100%' }}>
-                  <InputLabel id="status">申込状況</InputLabel>
-                  <Controller
-                    name="status"
-                    control={enrollmentStatusFormHandler.control}
-                    render={({ field }) => (
-                      <Select {...field} labelId="status" label="status">
-                        <MenuItem value={'仮申込'}>仮申込</MenuItem>
-                        <MenuItem value={'本申込'}>本申込</MenuItem>
-                        <MenuItem value={'受講中'}>受講中</MenuItem>
-                        <MenuItem value={'受講終了…'}>受講終了</MenuItem>
-                      </Select>
-                    )}
-                  />
-                </FormControl>
-              </Grid2>
-              <Grid2 size={6}>
-                <Button
-                  variant="contained"
-                  type="button"
-                  size="large"
-                  onClick={enrollmentStatusFormHandler.handleSubmit(
-                    updateEnrollmentStatus,
-                  )}
-                  sx={{ fontWeight: 'bold', color: 'white', width: '100%' }}
-                >
-                  更新
-                </Button>
-              </Grid2>
-              <Grid2 size={6}>
-                <Button
-                  variant="contained"
-                  type="button"
-                  color="error"
-                  size="large"
-                  onClick={handleStatusFormClose}
-                  sx={{ fontWeight: 'bold', color: 'white', width: '100%' }}
-                >
-                  キャンセル
-                </Button>
-              </Grid2>
-            </Grid2>
-          </Box> */}
         </Dialog>
       </Container>
     </Box>

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -8,3 +8,68 @@ export const fetcher = (url: string) =>
       console.log(err.message)
       throw err
     })
+
+export const validationRules = {
+  student: {
+    fullName: {
+      required: '氏名は必須です',
+    },
+    kana: {
+      pattern: {
+        // eslint-disable-next-line no-irregular-whitespace
+        value: /^$|^[ァ-ヶー\s　]+$/,
+        message: 'カナ名はカタカナとスペースのみを入力してください',
+      },
+    },
+    email: {
+      required: 'メールアドレスは必須です',
+      pattern: {
+        value: /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/,
+        message: '正しい形式のメールアドレスを入力してください。',
+      },
+    },
+    city: {
+      required: '居住地域は必須です',
+    },
+    age: {
+      min: {
+        value: 0,
+        message: '年齢は0歳以上である必要があります',
+      },
+      max: {
+        value: 150,
+        message: '年齢は150歳以下である必要があります',
+      },
+    },
+    gender: {
+      validate: (value: string) => {
+        return (
+          ['Male', 'Female', 'NON_BINARY', ''].includes(value) ||
+          '性別はMale, Female, NON_BINARY のいずれかを指定してください'
+        )
+      },
+    },
+  },
+  studentCourseList: {
+    courseName: {
+      required: 'コース名は必須です',
+    },
+    startData: {
+      required: '受講開始日は必須です',
+    },
+    endData: {
+      required: '受講修了予定日は必須です',
+    },
+    enrollmentStatus: {
+      status: {
+        required: '申込状況は必須です',
+        validate: (value: string) => {
+          return (
+            ['仮申込', '本申込', '受講中', '受講終了'].includes(value) ||
+            '申込状況は仮申込, 本申込, 受講中, 受講終了 のいずれかを指定してください'
+          )
+        },
+      },
+    },
+  },
+}


### PR DESCRIPTION
## 変更の概要
- 申込状況更新機能画面を実装しました
  - 受講生詳細画面に表示するコース一覧のテーブル列からフォームを呼び出せる仕様です
  - 現状の登録内容をデフォルト値として設定しています
  - ステータスが後ろに戻るような変更をした場合には、アラートでエラーメッセージを表示します

## なぜこの変更をするのか
- 画面上から申込状況を変更するため

## 変更内容
![無題の動画-‐-Clipchampで作成](https://github.com/user-attachments/assets/440b23dd-2bc0-4275-bec7-300ac90aa97e)

## どうやるのか
- 受講生詳細画面の受講コーステーブルの申込状況更新ボタンをクリック
- 表示されるフォームで申込状況を選択
- 更新ボタンを押下

## 課題
- API側のエラー修正が必要
#66 

