### PR TITLE
fix: 削除ボタンを押下時にページ遷移が発生するバグを修正しました

### DIFF
--- a/frontend/src/components/StudentTable.tsx
+++ b/frontend/src/components/StudentTable.tsx
@@ -15,7 +15,10 @@ import { StudentDetailProps } from '@/types'
 
 type StudentTableProps = {
   data: StudentDetailProps[]
-  deleteStudent: (studentDetail: StudentDetailProps) => void
+  deleteStudent: (
+    studentDetail: StudentDetailProps,
+    e: React.MouseEvent<HTMLButtonElement, MouseEvent>,
+  ) => void
 }
 
 const StudentTable: React.FC<StudentTableProps> = ({ data, deleteStudent }) => {
@@ -58,7 +61,7 @@ const StudentTable: React.FC<StudentTableProps> = ({ data, deleteStudent }) => {
                     variant="contained"
                     color="error"
                     size="small"
-                    onClick={() => deleteStudent(studentData)}
+                    onClick={(e) => deleteStudent(studentData, e)}
                   >
                     削除
                   </Button>

--- a/frontend/src/pages/students.tsx
+++ b/frontend/src/pages/students.tsx
@@ -8,7 +8,6 @@ import {
 } from '@mui/material'
 import axios, { AxiosError, AxiosResponse } from 'axios'
 import type { NextPage } from 'next'
-import Router from 'next/router'
 import { useEffect, useState } from 'react'
 import { SubmitHandler, useForm } from 'react-hook-form'
 import useSWR from 'swr'
@@ -146,7 +145,12 @@ const StudentPage: NextPage = () => {
     reset()
   }
 
-  const deleteStudent = (studentData: StudentDetailProps) => {
+  const deleteStudent = (
+    studentData: StudentDetailProps,
+    e: React.MouseEvent<HTMLButtonElement, MouseEvent>,
+  ) => {
+    e.stopPropagation()
+
     const confirmDelete = window.confirm(
       studentData.student.fullName + 'さんを本当に削除してよろしいですか？',
     )
@@ -169,7 +173,6 @@ const StudentPage: NextPage = () => {
             'さんを削除しました\n\n' +
             'データの復旧を希望の場合は管理者にお問い合わせください',
         )
-        Router.push('/')
       })
       .catch((err: AxiosError<{ error: string }>) => {
         console.log(err)


### PR DESCRIPTION
## 変更の概要
- 削除ボタンを押下時にページ遷移が発生するバグを修正しました
  - クリックイベントの伝播を止めるように修正しました

## なぜこの変更をするのか
- 削除ボタン押下時にcomfirm後、どちらを選んでも詳細画面への遷移が発生してしまっていたため

## 備考
単独でMerge可能なため直接mainブランチにプッシュします