### PR TITLE
fix: テストデータ修正時に落ちるようになっていたテストケースの修正を行いました

### DIFF
--- a/backend/src/test/java/portfolio/StudentManagement/repository/EnrollmentStatusRepositoryTest.java
+++ b/backend/src/test/java/portfolio/StudentManagement/repository/EnrollmentStatusRepositoryTest.java
@@ -105,13 +105,13 @@ class EnrollmentStatusRepositoryTest {
         EnrollmentStatus.builder()
             .id("bd9bf9l0-bbbb-7b20-8000-000000000006")
             .studentCourseId("bd9bf9l0-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
-            .status(Status.受講中)
+            .status(Status.仮申込)
             .createdAt(LocalDateTime.parse("2024-07-01T09:00:00"))
             .build(),
         EnrollmentStatus.builder()
             .id("bd9bf9l0-bbbb-7b20-8000-000000000015")
             .studentCourseId("bd9bf9l0-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
-            .status(Status.受講終了)
+            .status(Status.受講中)
             .createdAt(LocalDateTime.parse("2024-12-01T09:00:00"))
             .build(),
         EnrollmentStatus.builder()
@@ -147,7 +147,7 @@ class EnrollmentStatusRepositoryTest {
         EnrollmentStatus.builder()
             .id("hd9hj9r0-hhhh-7b20-8000-000000000012")
             .studentCourseId("hd9hj9r0-hhhh-hhhh-hhhh-hhhhhhhhhhhh")
-            .status(Status.受講終了)
+            .status(Status.受講中)
             .createdAt(LocalDateTime.parse("2023-07-01T09:00:00"))
             .build()
     );

--- a/backend/src/test/java/portfolio/StudentManagement/repository/StudentCourseRepositoryTest.java
+++ b/backend/src/test/java/portfolio/StudentManagement/repository/StudentCourseRepositoryTest.java
@@ -170,7 +170,7 @@ class StudentCourseRepositoryTest {
     EnrollmentStatus status6 = new EnrollmentStatus(
         "bd9bf9l0-bbbb-7b20-8000-000000000015",
         "bd9bf9l0-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
-        Status.valueOf("受講終了"), LocalDateTime.parse("2024-12-01T09:00:00")
+        Status.valueOf("受講中"), LocalDateTime.parse("2024-12-01T09:00:00")
     );
 
     EnrollmentStatus status7 = new EnrollmentStatus(
@@ -206,7 +206,7 @@ class StudentCourseRepositoryTest {
     EnrollmentStatus status12 = new EnrollmentStatus(
         "hd9hj9r0-hhhh-7b20-8000-000000000012",
         "hd9hj9r0-hhhh-hhhh-hhhh-hhhhhhhhhhhh",
-        Status.valueOf("受講終了"), LocalDateTime.parse("2023-07-01T09:00:00")
+        Status.valueOf("受講中"), LocalDateTime.parse("2023-07-01T09:00:00")
     );
 
     return Stream.of(


### PR DESCRIPTION
## 変更の概要
テストデータ修正時に落ちるようになっていたテストケースの修正
- テストデータの申込状況を修正した際に、同じデータを使っていた受講生コース情報などのテストが落ちるようになっていました
- 上記をデバッグするため、テストコードを修正しました

## 備考
上記の修正箇所以外の変更はマージ済です。