### PR TITLE
update: 受講生更新APIのエンドポイントにidを動的に受け取れるように修正し、PUTメソッドをPATCHメソッドに修正しました

### DIFF
--- a/backend/src/main/java/portfolio/StudentManagement/controller/StudentController.java
+++ b/backend/src/main/java/portfolio/StudentManagement/controller/StudentController.java
@@ -16,9 +16,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -332,10 +332,26 @@ public class StudentController {
           content = @Content(
               schema = @Schema(implementation = StudentDetail.class)
           )
-      )
+      ),
+      parameters = {
+          @Parameter(in = ParameterIn.PATH, name = "id",
+              required = true,
+              description = "受講生ID",
+              schema = @Schema(
+                  type = "string",
+                  format = "uuid",
+                  description = "UUID",
+                  example = "5998fd5d-a2cd-11ef-b71f-6845f15f510c"
+              )
+          )
+      }
   )
-  @PutMapping("/students")
-  public ResponseEntity<String> updateStudent(@RequestBody @Valid StudentDetail studentDetail)
+  @PatchMapping("/students/{id}")
+  public ResponseEntity<String> updateStudent(
+      @PathVariable @Pattern(
+          regexp = "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$")
+      String id,
+      @RequestBody @Valid StudentDetail studentDetail)
       throws StudentNotFoundException, StudentCourseNotFoundException {
     service.updateStudent(studentDetail);
     return ResponseEntity.ok("更新に成功しました");

--- a/backend/src/test/java/portfolio/StudentManagement/controller/StudentControllerTest.java
+++ b/backend/src/test/java/portfolio/StudentManagement/controller/StudentControllerTest.java
@@ -7,8 +7,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -351,7 +351,7 @@ class StudentControllerTest {
         """;
 
     // 実行と検証
-    mockMvc.perform(put("/api/students")
+    mockMvc.perform(patch("/api/students/9b1010ec-4e5b-46e5-8c26-9b4b23159b3d")
             .contentType("application/json")
             .content(body))
         .andExpect(status().isOk())
@@ -393,7 +393,7 @@ class StudentControllerTest {
         """;
 
     // 実行と検証
-    mockMvc.perform(put("/api/students")
+    mockMvc.perform(patch("/api/students/9b1010ec-4e5b-46e5-8c26-9b4b2359b3d")
             .contentType("application/json")
             .content(body))
         .andExpect(status().isBadRequest())
@@ -438,7 +438,7 @@ class StudentControllerTest {
         .when(service).updateStudent(any());
 
     // 実行と検証
-    mockMvc.perform(put("/api/students")
+    mockMvc.perform(patch("/api/students/9b1010ec-4e5b-46e5-8c26-9b4b23159b3d")
             .contentType("application/json")
             .content(body))
         .andExpect(status().isNotFound())
@@ -482,7 +482,7 @@ class StudentControllerTest {
         .when(service).updateStudent(any());
 
     // 実行と検証
-    mockMvc.perform(put("/api/students")
+    mockMvc.perform(patch("/api/students/9b1010ec-4e5b-46e5-8c26-9b4b23159b3d")
             .contentType("application/json")
             .content(body))
         .andExpect(status().isNotFound())

--- a/frontend/src/pages/students/[id].tsx
+++ b/frontend/src/pages/students/[id].tsx
@@ -40,10 +40,10 @@ const StudentDetail: NextPage = () => {
   }, [data, editFormHandler])
 
   const updateStudent: SubmitHandler<StudentDetailProps> = (formData) => {
-    const url = process.env.NEXT_PUBLIC_API_BASE_URL + '/students'
+    const url = process.env.NEXT_PUBLIC_API_BASE_URL + '/students/' + id
     const headers = { 'Content-Type': 'application/json' }
 
-    axios({ method: 'PUT', url: url, data: formData, headers: headers })
+    axios({ method: 'PATCH', url: url, data: formData, headers: headers })
       .then((res: AxiosResponse) => {
         res.status === 200 && mutate()
         alert(formData.student.fullName + 'さんの情報を更新しました')


### PR DESCRIPTION
## 変更の概要
- 受講生更新APIのエンドポイントを`/students`から`/students/{id}`に修正
- 受講生更新APIのHTTPメソッドをPUTからPATCHに修正
- 上記に伴い、フロントエンド側の設定も修正

#79 

## なぜこの変更をするのか
- 正しくHTTPメソッドを使用するため
- APIエンドポイントのベストプラクティスに乗っ取るため

